### PR TITLE
updates to FireRun.constrainByShape after pairing session

### DIFF
--- a/fireatlas/FireRun.py
+++ b/fireatlas/FireRun.py
@@ -609,7 +609,7 @@ def constrainByShape_Fire_Forward(tst, ted, perimeter_gdf, sat='SNPP'):
 
     # get lists of times to run fire_forward
     list_of_ts = list(FireTime.t_generator(tst, ted))
-    unique_ym = preprocess.check_preprocessed_file(list_of_ts, sat)
+    unique_ym = preprocess.check_preprocessed_file(tst, ted, sat)
 
     # preprocess the monthly files--will only do for those not already processed
     for ym in unique_ym:

--- a/fireatlas/preprocess.py
+++ b/fireatlas/preprocess.py
@@ -194,12 +194,11 @@ def check_preprocessed_file(
     -------
     list of unique combos of years and months (and days if NRT) that need to be processed
     """
-    fs = fsspec.filesystem(location)
     # check that there's viirs data for these dates and if not, keep track
     needs_processing = []
     for t in t_generator(tst, ted):
         filepath = preprocessed_filename(t, sat=sat, location=location)
-        if not fs.exists(filepath):
+        if not settings.fs.exists(filepath):
             needs_processing.append(t)
 
     if freq == "monthly":


### PR DESCRIPTION
forgot to commit these changes after our pairing session following the update to file structures.

Also, I think I fixed `check_preprocessed_file()`. It was searching for existing VIIRS files and indicating that they don't exist when they do.

`fs = fsspec.filesystem(location)` was in there, and when the default location value is `None`, it doesn't work. I used `settings.fs` instead to search if files exist and seems to work.