### PR TITLE
Quick And Easy .env Overrides without DPS Changes

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -29,5 +29,6 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/MAAP-Project/maap-py.git@develop
+    - awscli
 # NOTE: this env.yml is here for convenience but really all DPS and test installs leverage pyproject.toml
 # so if you change things here do community service and change pyproject.toml too :wink:

--- a/maap_runtime/run_dps_cli.sh
+++ b/maap_runtime/run_dps_cli.sh
@@ -103,6 +103,9 @@ source activate /opt/conda/envs/vanilla
 pushd "$basedir"
 { # try
   echo "Running in directory: $(pwd -P)"
+  # we now secretly look for s3://maap-ops-workspace/shared/gsfc_landslides/FEDSpreprocessed/<regnm>/.env
+  # and copy it locally to ../fireatlas/.env so that pydantic can pick up our overrides
+  aws s3 cp "s3://maap-ops-workspace/shared/gsfc_landslides/FEDSpreprocessed/${regnm}/.env" ../fireatlas/.env
 
   if [[ $selected_flag == "data-update" ]]; then
     scalene --cli --no-browser --reduced-profile --html --column-width 180 --outfile "${output_dir}/profile.html" --- FireRunDataUpdateChecker.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
   "rasterio",
   "pyproj",
   "tqdm",
-  "scalene"
+  "scalene",
+  "awscli"
 ]
 
 # [project.urls]


### PR DESCRIPTION
In conjunction with a scheduler PR: https://github.com/Earth-Information-System/fireatlas/pull/13

An example of .env overrides and how they will be incorporated before running algo.

Then `.env` in question here has:

```bash
FEDS_FTYP_OPT="preset"
FEDS_CONT_OPT="preset"
FEDS_EPSG_CODE=3571
```