### PR TITLE
Do not filter combined LF perimeter output

### DIFF
--- a/fireatlas/postprocess.py
+++ b/fireatlas/postprocess.py
@@ -200,8 +200,9 @@ def save_snapshot_layers(allfires_gdf_t, region: Region, tst: TimeStep, ted: Tim
 
     for layer in ["perimeter", "fireline", "newfirepix"]:
         data = create_snapshot_data(allfires_gdf_t, layer, region, dt)
-        # only include perimeters what are active or may reactivate
-        data = data[(data['isactive'] == 1) | (data['mayreactivate'] == 1)]
+        if layer == "perimeter":
+            # only include perimeters what are active or may reactivate
+            data = data[(data['isactive'] == 1) | (data['mayreactivate'] == 1)]
         data.to_file(os.path.join(output_dir, f"{layer}.fgb"), driver="FlatGeobuf")
 
 

--- a/fireatlas/postprocess.py
+++ b/fireatlas/postprocess.py
@@ -177,9 +177,6 @@ def create_snapshot_data(
             data["geom_counts"] > 5, 1, 0
         )  # if more than 5 geometries are present, flag it
 
-        # only include perimeters what are active or may reactivate
-        data = data[(data['isactive'] == 1) | (data['mayreactivate'] == 1)]
-
     data["region"] = str(region[0])
 
     data['t'] = data['t'].dt.strftime('%Y-%m-%dT%H:%M:%S')
@@ -203,6 +200,8 @@ def save_snapshot_layers(allfires_gdf_t, region: Region, tst: TimeStep, ted: Tim
 
     for layer in ["perimeter", "fireline", "newfirepix"]:
         data = create_snapshot_data(allfires_gdf_t, layer, region, dt)
+        # only include perimeters what are active or may reactivate
+        data = data[(data['isactive'] == 1) | (data['mayreactivate'] == 1)]
         data.to_file(os.path.join(output_dir, f"{layer}.fgb"), driver="FlatGeobuf")
 
 


### PR DESCRIPTION
Fixes https://github.com/Earth-Information-System/fireatlas/issues/45

Changes:

* Only filter snapshot output on `isactive` and `mayreactivate` and leave combined LF output alone (for perimeter layer)