### PR TITLE
Tweaks while running performance tests

### DIFF
--- a/fireatlas/DataCheckUpdate.py
+++ b/fireatlas/DataCheckUpdate.py
@@ -65,7 +65,7 @@ def update_VJ114IMGTDL(d: date):
     urldir = "https://nrt4.modaps.eosdis.nasa.gov/api/v2/content/archives/FIRMS/noaa-20-viirs-c2/Global/"
     urlfnm = urldir + "J1_VIIRS_C2_Global_VJ114IMGTDL_NRT_"+d.strftime('%Y%j')+".txt"
     try:
-        wget(url=urlfnm,locdir=data_dir,robots_off=True,no_wget=False,timestamping=True,header='NASA')
+        downloaded_filepath = wget(url=urlfnm,locdir=data_dir,robots_off=True,no_wget=False,timestamping=True,header='NASA')
         preprocess_input_file(downloaded_filepath)
     except Exception as e:
         logger.warning(f"Could not download VJ114IMGTDL data for {d}")

--- a/fireatlas/DataCheckUpdate.py
+++ b/fireatlas/DataCheckUpdate.py
@@ -65,7 +65,7 @@ def update_VJ114IMGTDL(d: date):
     urldir = "https://nrt4.modaps.eosdis.nasa.gov/api/v2/content/archives/FIRMS/noaa-20-viirs-c2/Global/"
     urlfnm = urldir + "J1_VIIRS_C2_Global_VJ114IMGTDL_NRT_"+d.strftime('%Y%j')+".txt"
     try:
-        downloaded_filepath = wget(url=urlfnm,locdir=data_dir,robots_off=True,no_wget=False,timestamping=True,header='NASA')
+        wget(url=urlfnm,locdir=data_dir,robots_off=True,no_wget=False,timestamping=True,header='NASA')
         preprocess_input_file(downloaded_filepath)
     except Exception as e:
         logger.warning(f"Could not download VJ114IMGTDL data for {d}")

--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -49,6 +49,8 @@ class Settings(BaseSettings):
         description="Final storage place for written files. This is where everything reads from",
     )
 
+    LOG_FILENAME: str = Field("running.log", description="Where to write logs to.")
+
     # ------------------------------------------------------------------------------
     # spatiotemporal constraints of fire objects
     # ------------------------------------------------------------------------------

--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -143,6 +143,9 @@ class Settings(BaseSettings):
     export_to_veda: bool = Field(
         False, description="whether to export data from MAAP to VEDA s3"
     )
+    N_DASK_WORKERS: bool = Field(
+        6, description="How many dask workers to use for Run."
+    )
 
     # ------------------------------------------------------------------------------
     # fire type related parameters

--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -143,7 +143,7 @@ class Settings(BaseSettings):
     export_to_veda: bool = Field(
         False, description="whether to export data from MAAP to VEDA s3"
     )
-    N_DASK_WORKERS: bool = Field(
+    N_DASK_WORKERS: int = Field(
         6, description="How many dask workers to use for Run."
     )
 

--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -212,7 +212,7 @@ def read_geojson_nv_CA(y0=2012, y1=2019):
     return gdf
 
 
-def VNP14IMGML_filepath(t: TimeStep, ver="C1.05"):
+def VNP14IMGML_filepath(t: TimeStep):
     """Filepath for monthly S-NPP VIIRS data
 
     Parameters
@@ -233,9 +233,9 @@ def VNP14IMGML_filepath(t: TimeStep, ver="C1.05"):
         "VNP14IMGML",
     )
 
-    filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.{ver}.txt.gz")
+    filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.C1.05.txt")
     if not settings.fs.exists(filepath):
-        filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.{ver}.txt")
+        filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.C2.01.txt")
     if not settings.fs.exists(filepath):
         print("No data available for file", filepath)
         return

--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -297,7 +297,7 @@ def VNP14IMGTDL_filepath(t: TimeStep):
     filepath : str
         Path to input data or None if file does not exist
     """
-    d = FireTime.t2dt(t)
+    d = date(t[0], t[1], t[2])
 
     filepath = os.path.join(
         settings.dirextdata,
@@ -455,7 +455,7 @@ def VJ114IMGTDL_filepath(t: TimeStep):
     filepath : str
         Path to input data or None if file does not exist
     """
-    d = FireTime.t2dt(t)
+    d = date(t[0], t[1], t[2])
 
     filepath = os.path.join(
         settings.dirextdata,

--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -2103,7 +2103,6 @@ def copy_from_local_to_s3(filepath: str, fs: s3fs.S3FileSystem, **tags):
     Some default tags will be added from the environment and specified FireConsts
     """
     dst = filepath.replace(settings.LOCAL_PATH, settings.S3_PATH)
-    logger.info(f"uploading file {filepath} to {dst}")
 
     fs.put_file(filepath, dst)
 

--- a/fireatlas/FireLog.py
+++ b/fireatlas/FireLog.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from fireatlas import settings
 
 _logger_configured = False
 
@@ -18,7 +19,7 @@ def get_logger(name):
         ch.setLevel(logging.INFO)
 
         # create a file handler as well
-        fh = logging.FileHandler(os.path.join(root_dir, "running.log"))
+        fh = logging.FileHandler(os.path.join(root_dir, settings.LOG_FILENAME))
         fh.setLevel(logging.INFO)
 
         formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -456,12 +456,7 @@ def Fire_merge_rtree(allfires, fids_ne, fids_ea, fids_sleep):
     return allfires
 
 @timed
-def Fire_Forward_one_step(allfires, allpixels, tst, t, region):
-    from fireatlas.postprocess import (
-        save_allpixels,
-        save_allfires_gdf
-    )
-    
+def Fire_Forward_one_step(allfires, allpixels, tst, t, region):    
     logger.info("--------------------")
     logger.info(f"Fire tracking at {t}")
 
@@ -506,10 +501,6 @@ def Fire_Forward_one_step(allfires, allpixels, tst, t, region):
     # 10. update allfires gdf
     allfires.update_gdf()
 
-    # 11. save allpixels and allfires locally for up to t
-    save_allpixels(allpixels, tst, t, region)
-    save_allfires_gdf(allfires.gdf, tst, t, region)
-    
     return allfires
 
 
@@ -538,6 +529,8 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
     from fireatlas.postprocess import (
         get_t_of_last_allfires_run,
         read_allpixels,
+        save_allfires_gdf,
+        save_allpixels,
     )
     from fireatlas.FireObj import Allfires
 
@@ -607,6 +600,10 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
     # loop over every t during the period, mutate allfires, allpixels, save
     for t in list_of_ts:
         allfires = Fire_Forward_one_step(allfires, allpixels, tst, t, region)
+
+    # save allpixels and allfires locally for ted
+    save_allpixels(allpixels, tst, ted, region)
+    save_allfires_gdf(allfires.gdf, tst, ted, region)
 
     return allfires, allpixels, t_saved
 

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -161,6 +161,8 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
         else:
             ampm = 'AM'
         ted = [ctime.year, ctime.month, ctime.day, ampm]
+    
+    logger.info(f"------------- Starting full run from {tst=} to {ted=} -------------")
 
     client = Client(n_workers=MAX_WORKERS)
     logger.info(f"dask workers = {len(client.cluster.workers)}")

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -178,7 +178,7 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
         glob.glob(f"{settings.LOCAL_PATH}/{settings.PREPROCESSED_DIR}/*/*.txt")
     )
     # block until half-day timesteps and region are on s3
-    timed(client.gather, text="Dask upload")([*data_upload_futures, region_future])
+    timed(client.gather, text=f"Dask upload of {len(data_upload_futures) + 1} files")([*data_upload_futures, region_future])
 
     logger.info("------------- Done with preprocessing t -------------")
 
@@ -211,7 +211,8 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
         glob.glob(os.path.join(data_dir, "*", f"{ted[0]}{ted[1]:02}{ted[2]:02}{ted[3]}", "*.fgb"))
     )
     # block until everything is uploaded
-    timed(client.gather, text="Dask upload")([*fgb_s3_upload_futures, *fgb_veda_upload_futures])
+    futures = [*fgb_s3_upload_futures, *fgb_veda_upload_futures]
+    timed(client.gather, text=f"Dask upload of {len(futures)} files")(futures)
 
     logger.info("------------- Done -------------")
 

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -178,7 +178,7 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
         glob.glob(f"{settings.LOCAL_PATH}/{settings.PREPROCESSED_DIR}/*/*.txt")
     )
     # block until half-day timesteps and region are on s3
-    client.gather([*data_upload_futures, region_future])
+    timed(client.gather, text="Dask upload")([*data_upload_futures, region_future])
 
     logger.info("------------- Done with preprocessing t -------------")
 
@@ -211,7 +211,7 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
         glob.glob(os.path.join(data_dir, "*", f"{ted[0]}{ted[1]:02}{ted[2]:02}{ted[3]}", "*.fgb"))
     )
     # block until everything is uploaded
-    client.gather([*fgb_s3_upload_futures, *fgb_veda_upload_futures])
+    timed(client.gather, text="Dask upload")([*fgb_s3_upload_futures, *fgb_veda_upload_futures])
 
     logger.info("------------- Done -------------")
 

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -6,6 +6,7 @@ from functools import partial
 
 import s3fs
 
+import dask.config
 from dask.distributed import Client
 from datetime import datetime, date, timezone, timedelta
 
@@ -37,6 +38,8 @@ from fireatlas.FireIO import copy_from_local_to_s3, copy_from_local_to_veda_s3, 
 from fireatlas.FireTime import t_generator
 from fireatlas.FireLog import logger
 from fireatlas import settings
+
+dask.config.set({'logging.distributed': 'error'})
 
 # NOTE: the current eis queue 64gb is set up as an
 # AWS r5.2xlarge instance with 64gb RAM and 8 CPUs

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -68,7 +68,7 @@ def get_timesteps_needing_region_t_processing(
     return needs_processing
 
 
-def job_fire_forward(region: Region, tst: TimeStep, ted: TimeStep):
+def job_fire_forward(client: Client, region: Region, tst: TimeStep, ted: TimeStep):
     logger.info(f"Running FireForward code for {region[0]} from {tst} to {ted} with source {settings.FIRE_SOURCE}")
 
     try:
@@ -87,7 +87,7 @@ def job_fire_forward(region: Region, tst: TimeStep, ted: TimeStep):
 
     large_fires = find_largefires(allfires_gdf)
     save_large_fires_nplist(allpixels, region, large_fires, tst)
-    save_large_fires_layers(allfires_gdf, region, large_fires, tst, ted)
+    save_large_fires_layers(allfires_gdf, region, large_fires, tst, ted, client=client)
 
 
 def job_preprocess_region_t(t: TimeStep, region: Region):
@@ -196,7 +196,7 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
     logger.info("------------- Done with preprocessing region + t -------------")
     
     # run fire forward algorithm (which cannot be run in parallel)
-    job_fire_forward(region=region, tst=tst, ted=ted)
+    job_fire_forward(region=region, tst=tst, ted=ted, client=client)
 
     # take all fire forward output and upload all outputs in parallel
     data_dir = all_dir(tst, region, location="local")

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -41,9 +41,6 @@ from fireatlas import settings
 
 dask.config.set({'logging.distributed': 'error'})
 
-# NOTE: the current eis queue 64gb is set up as an
-# AWS r5.2xlarge instance with 64gb RAM and 8 CPUs
-MAX_WORKERS = 6
 
 # NOTE: this expects credentials to be resolvable globally
 # via boto3/botocore common resolution paths
@@ -189,7 +186,7 @@ def Run(region: Region, tst: TimeStep, ted: TimeStep):
     
     logger.info(f"------------- Starting full run from {tst=} to {ted=} -------------")
 
-    client = Client(n_workers=MAX_WORKERS)
+    client = Client(n_workers=settings.N_DASK_WORKERS)
     logger.info(f"dask workers = {len(client.cluster.workers)}")
  
     # run the first two jobs in parallel

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -92,12 +92,13 @@ def job_fire_forward(client: Client, region: Region, tst: TimeStep, ted: TimeSte
         # allfires and allpixels save for this ted timestep
         t_saved = ted
 
-
-    save_snapshots(allfires_gdf, region, t_saved, ted)
+    snapshot_futures = save_snapshots(allfires_gdf, region, t_saved, ted, client=client)
 
     large_fires = find_largefires(allfires_gdf)
     save_large_fires_nplist(allpixels, region, large_fires, tst)
     save_large_fires_layers(allfires_gdf, region, large_fires, tst, ted, client=client)
+    
+    client.gather(snapshot_futures)
 
 
 def job_preprocess_region_t(t: TimeStep, region: Region):

--- a/fireatlas/postprocess.py
+++ b/fireatlas/postprocess.py
@@ -12,6 +12,9 @@ from shapely.ops import unary_union
 import warnings
 
 warnings.filterwarnings("ignore", "GeoSeries.notna", UserWarning)
+warnings.filterwarnings("ignore", "Large object * detected in task graph", UserWarning)
+warnings.filterwarnings("ignore", "Sending large graph", UserWarning)
+
 
 from fireatlas.utils import timed
 from fireatlas.FireTypes import Region, TimeStep, Location

--- a/fireatlas/utils.py
+++ b/fireatlas/utils.py
@@ -3,7 +3,7 @@ from time import time
 from fireatlas.FireLog import logger
 
 
-def timed(f):
+def timed(f, text: str | None = None):
 
     @wraps(f)
     def wrap(*args, **kwargs):
@@ -28,7 +28,7 @@ def timed(f):
             took = f"{t_diff * 1000:.2f} ms"
 
         # log the time that the function took
-        logger.info(f"func:{f.__name__} took: {took}")
+        logger.info(f"func:{text or f.__name__} took: {took}")
         return result
 
     return wrap


### PR DESCRIPTION
The big changes are:

- Only save `allpixels` and `allfires_gdf` at the end of `Fire_Forward` rather than on every `t`
- Add optional `client` kwarg to `save_large_fire_layers` and `save_snapshots` to enable easy parallelization of those steps via dask
- Preprocess daily input files when monthly aren't available -- even if the daily files are not freshly updated from upstream
- Use either version of SNPP monthly files (C2.01 _or_ C1.05)
- Make log location and number of dask workers configurable from settings
