### PR TITLE
Pin geopandas==0.14.2

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -6,7 +6,7 @@ dependencies:
   - pandas
   - dask
   - distributed
-  - geopandas
+  - geopandas=0.14.2
   - shapely
   - fsspec
   - jupyterlab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "pandas",
   "dask",
   "distributed",
-  "geopandas",
+  "geopandas==0.14.2",
   "fiona",
   "shapely",
   "fsspec",


### PR DESCRIPTION
Pin geopandas at version 0.14.2 while we evaluate potential breaking changes from geopandas 1.0.0. 

See [issue 61](https://github.com/Earth-Information-System/fireatlas/issues/61).