### PR TITLE
Fix typo in FTYP_OPT and CONT_OP literals

### DIFF
--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -145,10 +145,10 @@ class Settings(BaseSettings):
     # ------------------------------------------------------------------------------
     # fire type related parameters
     # ------------------------------------------------------------------------------
-    FTYP_OPT: Literal["preset", "CA", "Global"] = Field(
+    FTYP_OPT: Literal["preset", "CA", "global"] = Field(
         "CA", description="fire type option"
     )
-    CONT_OPT: Literal["preset", "CA", "Global"] = Field(
+    CONT_OPT: Literal["preset", "CA", "global"] = Field(
         "CA", description="continuity threshold option"
     )
 


### PR DESCRIPTION
Fix typo in FTYP_OPT and CONT_OP literals to match lookup tables.