### PR TITLE
NOAA20

### DIFF
--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -106,7 +106,7 @@ class Settings(BaseSettings):
 
     # fire source data
     FIRE_SOURCE: Literal["SNPP", "NOAA20", "VIIRS", "BAMOD"] = Field(
-        "VIIRS", description="fire source data"
+        "NOAA20", description="fire source data"
     )
     FIRE_NRT: bool = Field(True, description="whether to use NRT data")
     FIRE_SENSOR: Literal["viirs", "mcd64"] = Field("viirs", description="fire sensor")

--- a/notebooks/11_Archive.ipynb
+++ b/notebooks/11_Archive.ipynb
@@ -80,7 +80,9 @@
     "\n",
     "Check to see if all the files that we need have already been processed and are available on s3.\n",
     "\n",
-    "Note: \"NOAA20\" files for this time period are not in the input folder so we will only use \"SNPP\""
+    "Note: \"NOAA20\" files for this time period are not in the input folder so we will only use \"SNPP\". Another way to do this\n",
+    "for DPS jobs is to override the `FIRE_SOURCE` constant. You can export an os environment \n",
+    "variable called `FEDS_FIRE_SOURCE='VIIRS'` or `FEDS_FIRE_SOURCE='SNPP'`"
    ]
   },
   {


### PR DESCRIPTION
Using SUOMI on v3 is now killing jobs. So defaulting to `NOAA20`. I checked all call sites and this should "just" work. What this changes is that now anyone doing archival runs needs to set `FEDS_FIRE_SOURCE='VIIRS'` to get it to work

```bash
2024-07-14 21:51:53,237 - distributed.worker - WARNING - Compute Failed
Key:       preprocess_input_file-849c1f44bcf84da8111ab869f4f8c23b
State:     executing
Function:  preprocess_input_file
args:      ('s3://maap-ops-workspace/shared/gsfc_landslides/FEDSinput/VIIRS/VNP14IMGTDL/SUOMI_VIIRS_C2_Global_VNP14IMGTDL_NRT_2024194.txt')
kwargs:    {}
Exception: 'ValueError("Usecols do not match columns, columns expected but not found: [\'daynight\', \'track\', \'latitude\', \'acq_date\', \'longitude\', \'frp\', \'scan\', \'acq_time\', \'confidence\']")'
```