### PR TITLE
only use NOAA20 as input source

### DIFF
--- a/FireConsts.py
+++ b/FireConsts.py
@@ -61,7 +61,7 @@ area_VI = 0.141  # km2, area of each 375m VIIRS pixel
 MCD64buf = 231.7  # MODIS fire perimeter buffer (deg), corresponding to 463.31271653 m/2
 
 # fire source data
-firesrc = "VIIRS"  # source - ['SNPP', 'NOAA20', 'VIIRS', 'BAMOD']:
+firesrc = "NOAA20"  # source - ['SNPP', 'NOAA20', 'VIIRS', 'BAMOD']:
 firenrt = True # NRT - True, False
 firessr = "viirs"  # sensor - 'mcd64'
 


### PR DESCRIPTION
@ranchodeluxe I am unable to run any tests right now, but I'm hoping that changing the source will fix the Soumi outage. 