### PR TITLE
Make Pydantic .env Lookup Absolute

### DIFF
--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -14,11 +14,12 @@ from fireatlas.FireTypes import Location
 
 root_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
+DOTENV_ABS_PATH = os.path.join(os.path.dirname(__file__), ".env")
 
 class Settings(BaseSettings):
     # read in all env vars prefixed with `FEDS_` they can be in a .env file
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore", env_prefix="FEDS_")
+    model_config = SettingsConfigDict(env_file=DOTENV_ABS_PATH, extra="ignore", env_prefix="FEDS_")
     
     # ------------------------------------------------------------------------------
     # where data is stored

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -46,6 +46,7 @@ dask.config.set({'logging.distributed': 'error'})
 # via boto3/botocore common resolution paths
 fs = s3fs.S3FileSystem(config_kwargs={"max_pool_connections": 10})
 
+logger.info(settings.model_dump())
 
 def validate_json(s):
     try:

--- a/maap_runtime/run_dps_cli.sh
+++ b/maap_runtime/run_dps_cli.sh
@@ -118,6 +118,7 @@ pushd "$basedir"
   # we now secretly look for s3://maap-ops-workspace/shared/gsfc_landslides/FEDSpreprocessed/<regnm>/.env
   # and copy it locally to ../fireatlas/.env so that pydantic can pick up our overrides
   copy_s3_object "s3://maap-ops-workspace/shared/gsfc_landslides/FEDSpreprocessed/${regnm}/.env" ../fireatlas/.env
+  ls -lah ../fireatlas/
 
   if [[ $selected_flag == "data-update" ]]; then
     #scalene --cli --no-browser --reduced-profile --html --column-width 180 --outfile "${output_dir}/profile.html" --- FireRunDataUpdateChecker.py


### PR DESCRIPTION
# Problem

Our DPS jobs call into the main `FireRunDaskCoordinator.py` from within `fireatlas/maap_runtime` so... `python3 ../fireatlas/FireRunDaskCoordinator.py --regnm="ArchiveCONUS2019" --bbox="[-126.401171875,24.071240929282325,-61.36210937500001,49.40003415463647]" --tst="[2019,1,1,\"AM\"]" --ted="[2019,4,1,\"PM\"]"`

For some reason pydantic is looking for the file relative to the current working directory from which the python script is executed 😞 

But if you call it from within `/fireatlas/` so... `python3 FireRunDaskCoordinator.py --regnm="ArchiveCONUS2019" --bbox="[-126.401171875,24.071240929282325,-61.36210937500001,49.40003415463647]" --tst="[2019,1,1,\"AM\"]" --ted="[2019,4,1,\"PM\"]"`

then everything works


# Solution

force the lookup to be absolute like this PR does