### PR TITLE
Query Different Collection DataCheckUpdate.py

### DIFF
--- a/DataCheckUpdate.py
+++ b/DataCheckUpdate.py
@@ -282,7 +282,7 @@ def update_VNP14IMGTDL(local_dir=None):
     dstart = dstart - timedelta(days=1)              # downloaded the last file again to avoid incomplete data
 
     # Do the download process
-    urldir = "https://nrt4.modaps.eosdis.nasa.gov/api/v2/content/archives/FIRMS/suomi-npp-viirs-c2/Global/"
+    urldir = "https://nrt3.modaps.eosdis.nasa.gov/api/v2/content/archives/FIRMS/suomi-npp-viirs-c2/Global/"
     for d in pd.date_range(dstart,today):
         urlfnm = urldir + "SUOMI_VIIRS_C2_Global_VNP14IMGTDL_NRT_"+d.strftime('%Y%j')+".txt"
         try: strcmd = wget(url=urlfnm,locdir=local_dir,robots_off=True,no_wget=False,timestamping=True,header='NASA')
@@ -317,7 +317,7 @@ def update_VJ114IMGTDL(local_dir=None):
     dstart = dstart - timedelta(days=1)              # downloaded the last file again to avoid incomplete data
 
     # Do the download process
-    urldir = "https://nrt4.modaps.eosdis.nasa.gov/api/v2/content/archives/FIRMS/noaa-20-viirs-c2/Global/"
+    urldir = "https://nrt3.modaps.eosdis.nasa.gov/api/v2/content/archives/FIRMS/noaa-20-viirs-c2/Global/"
     for d in pd.date_range(dstart,today):
         urlfnm = urldir + "J1_VIIRS_C2_Global_VJ114IMGTDL_NRT_"+d.strftime('%Y%j')+".txt"
         try: strcmd = wget(url=urlfnm,locdir=local_dir,robots_off=True,no_wget=False,timestamping=True,header='NASA')


### PR DESCRIPTION
LAADS DAAC uses nrt4 as the backup to nrt3. nrt 4 was missing a few days that were present on nrt3. Seems best practice to use the primary instead of the backup anyway