### PR TITLE
Change FIRE_SOURCE back to VIIRS; turns SNPP back on

### DIFF
--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -116,7 +116,7 @@ class Settings(BaseSettings):
 
     # fire source data
     FIRE_SOURCE: Literal["SNPP", "NOAA20", "VIIRS", "BAMOD"] = Field(
-        "NOAA20", description="fire source data"
+        "VIIRS", description="fire source data"
     )
     FIRE_NRT: bool = Field(True, description="whether to use NRT data")
     FIRE_SENSOR: Literal["viirs", "mcd64"] = Field("viirs", description="fire sensor")


### PR DESCRIPTION
In [77](https://github.com/Earth-Information-System/fireatlas/pull/77) we turned ingestion from SNPP off because the satellite had an outage and the failure of SNPP ingest cascaded into the rest of the system. SNPP is back up and running, so turning it back on [(136).](https://github.com/Earth-Information-System/fireatlas/issues/136) 

@ranchodeluxe clarifying question on release workflow: to get this fix into our production runs, do I need to follow the [release workflow](https://github.com/Earth-Information-System/fireatlas/blob/conus-dps/docs/releasing.md), e.g. make this 1.2.2? 

