### PR TITLE
Zb/slack alerts

### DIFF
--- a/.github/workflows/schedule-alert-failed-dps-jobs.yaml
+++ b/.github/workflows/schedule-alert-failed-dps-jobs.yaml
@@ -36,9 +36,6 @@ jobs:
         with:
           maap_pgt_secret: ${{ secrets.MAAP_PGT }}
           email_pw_secret: ${{ secrets.EMAIL_PW }}
-
-      - name: Force failure for testing 
-        run: exit 1
         
       - name: send alert on Slack if failure
         if: always() 

--- a/.github/workflows/schedule-alert-failed-dps-jobs.yaml
+++ b/.github/workflows/schedule-alert-failed-dps-jobs.yaml
@@ -37,3 +37,14 @@ jobs:
           maap_pgt_secret: ${{ secrets.MAAP_PGT }}
           email_pw_secret: ${{ secrets.EMAIL_PW }}
 
+      - name: send alert on Slack if failure
+        if: always() 
+        uses: ravsamhq/notify-slack-action@2.5.0
+        with: 
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: "DPS Job Failed"
+          footer: "<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|View Failure>"
+        env: 
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK_WEBHOOK_URL }}
+            

--- a/.github/workflows/schedule-alert-failed-dps-jobs.yaml
+++ b/.github/workflows/schedule-alert-failed-dps-jobs.yaml
@@ -46,8 +46,8 @@ jobs:
         with: 
           status: ${{ job.status }}
           notify_when: 'failure'
-          notification_title: "DPS Job Failed"
-          footer: "<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|View Failure>"
+          notification_title: "DPS Job Failed - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|View Failed Run>"
+          footer: "<${{github.server_url}}/${{github.repository}}/issues/|Open GitHub Issues>"
         env: 
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK_WEBHOOK_URL }}
             

--- a/.github/workflows/schedule-alert-failed-dps-jobs.yaml
+++ b/.github/workflows/schedule-alert-failed-dps-jobs.yaml
@@ -37,6 +37,9 @@ jobs:
           maap_pgt_secret: ${{ secrets.MAAP_PGT }}
           email_pw_secret: ${{ secrets.EMAIL_PW }}
 
+      - name: Force failure for testing 
+        run: exit 1
+        
       - name: send alert on Slack if failure
         if: always() 
         uses: ravsamhq/notify-slack-action@2.5.0


### PR DESCRIPTION
Working on #140. As per that discussion, there are multiple levels of monitoring we need to add, as there are multiple places that we can run into trouble. @ranchodeluxe already created a system to alert when a DPS job fails with the [schedule-alert-failed-jobs workflow](https://github.com/Earth-Information-System/fireatlas/actions/workflows/schedule-alert-failed-dps-jobs.yaml) that effectively addresses the case where a DPS job fails. 

Unfortunately, GitHub only sends an email to the originator of the workflow, and doesn't have a way to easily add more recipients (e.g., me). We could use the GitHub-Slack integration to send notifications for the workflow to a dedicated Slack channel, but also unfortunately that integration provides no way to filter to only failures. So, even if our runs are failing, we would be getting spammed with 23 false positives/day and the 1 actual problem would be buried in that stream. 

So, I set up a simple Slack app and webhook that will send a message to a dedicated channel in our Slack workspace ONLY when the action fails. This PR just adds the logic for calling that. Luckily, we aren't the first team to have this problem and most of the work has already been done for us. 