### PR TITLE
Prep for release 1.2.5

### DIFF
--- a/.github/workflows/manual-v3.yaml
+++ b/.github/workflows/manual-v3.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'eis-feds-dask-coordinator-v3'
       github_ref:
-        description: 'Branch name or version tag, e.g: 1.2.4'
+        description: 'Branch name or version tag, e.g: 1.2.5'
         required: true
       username:
         description: 'Your MAAP username'

--- a/.github/workflows/schedule-bolivia_NOAA20-nrt.yaml
+++ b/.github/workflows/schedule-bolivia_NOAA20-nrt.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.2.4
+          github_ref: 1.2.5
           username: mccabete
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-borealna-nrt-v3.yaml
+++ b/.github/workflows/schedule-borealna-nrt-v3.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.2.4
+          github_ref: 1.2.5
           username: zbecker
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-conus-nrt-v3.yaml
+++ b/.github/workflows/schedule-conus-nrt-v3.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
       with:
         algo_name: eis-feds-dask-coordinator-v3
-        github_ref: 1.2.4
+        github_ref: 1.2.5
         username: zbecker
         queue: maap-dps-eis-worker-128gb
         maap_image_env: ubuntu

--- a/.github/workflows/schedule-hawaii-nrt-v3.yaml
+++ b/.github/workflows/schedule-hawaii-nrt-v3.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.2.4
+          github_ref: 1.2.5
           username: zbecker
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-nrt-date-update-current-day.yaml
+++ b/.github/workflows/schedule-nrt-date-update-current-day.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.2.4
+          github_ref: 1.2.5
           username: zbecker
           queue: maap-dps-eis-worker-32gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-russia-east-nrt-v3.yaml
+++ b/.github/workflows/schedule-russia-east-nrt-v3.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.2.4
+          github_ref: 1.2.5
           username: zbecker
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/maap_runtime/coordinator/algorithm_config.yaml
+++ b/maap_runtime/coordinator/algorithm_config.yaml
@@ -1,6 +1,6 @@
 algorithm_name: eis-feds-dask-coordinator-v3
 algorithm_description: "coordinator for all regional jobs, preprocess and FireForward steps"
-algorithm_version: 1.2.4
+algorithm_version: 1.2.5
 environment: ubuntu
 repository_url: https://github.com/Earth-Information-System/fireatlas.git
 docker_container_url: "mas.maap-project.org/root/maap-workspaces/custom_images/maap_base:v4.1.0"

--- a/maap_runtime/run_dps_build.sh
+++ b/maap_runtime/run_dps_build.sh
@@ -12,8 +12,6 @@ pushd "$basedir"
 
 conda create -n "fire_env" python=3.11
 source activate fire_env
-conda install pip 
-which -a pip
 
 echo "Doing fireatlas install next..."
 /opt/conda/envs/fire_env/bin/pip install -e ..


### PR DESCRIPTION
The recent Python 3.13 release is causing DPS image build to fail with something in our requirements. Creating a new release with pinned 3.11.