### PR TITLE
Zb/crs strings

### DIFF
--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -66,7 +66,7 @@ class Settings(BaseSettings):
         4, description="fire area threshold for determining large fires"
     )
 
-    EPSG_CODE: int = Field(
+    EPSG_CODE: int | str= Field(
         9311,
         description="epsg projection code ( 3571: North Pole LAEA; 32610: WGS 84 / UTM zone 10N; 9311: US National Atlas Equal Area)",
     )

--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -6,6 +6,7 @@ running controls
 from typing import Literal
 import os
 import warnings
+from pyproj import CRS
 
 import fsspec
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -73,10 +74,33 @@ class Settings(BaseSettings):
     @field_validator("EPSG_CODE")
     @classmethod
     def check_epsg(cls, epsg: int):
-        allowed = (3571, 32610, 9311, 6933)
+        allowed = (
+            3571, 
+            32610, 
+            9311, 
+            6933, 
+            "ESRI:102008", 
+            "EPSG:10603",
+            "EPSG:7764",
+            "ESRI:102022",
+            "EPSG:10601",
+            "EPSG:6933",
+            "EPSG:10601",
+            "EPSG:8859",
+            "EPSG:3576",
+            "EPSG:3575",
+            "EPSG:3035",
+            "EPSG:3576"
+        )
         if epsg not in allowed:
             warnings.warn(
                 f"EPSG projection code {epsg} not recognized as one of: {allowed}. (A new code can be registered in FireConsts.py if needed.)"
+            )
+
+        crs = CRS.from_user_input(epsg)
+        if not crs.is_projected:
+            warnings.warn(
+                f"FEDS assumes a projected coordinate system, but user-specified code {epsg} was not recognized as projected."
             )
         return epsg
 

--- a/fireatlas/FireGpkg.py
+++ b/fireatlas/FireGpkg.py
@@ -130,7 +130,7 @@ def make_gdf_snapshot(allfires, regnm, layer="perimeter"):
 
     if gdf is None:  # when no previous time step data, initialize the GeoDataFrame
         gdf = gpd.GeoDataFrame(
-                columns=(list(dd.keys()) + ["fireID"]), crs="epsg:" + str(settings.EPSG_CODE), geometry=[]
+                columns=(list(dd.keys()) + ["fireID"]), crs=str(settings.EPSG_CODE), geometry=[]
             )
 
         gdf = gdf.set_index("fireID") # set fid column as the index column
@@ -306,7 +306,7 @@ def save_gdf_uptonow(t, regnm):
         "t_ed": "datetime64",
     }
     gdf = gpd.GeoDataFrame(
-        columns=(list(dd.keys()) + ["fireID"]), crs="epsg:" + str(settings.EPSG_CODE), geometry=[]
+        columns=(list(dd.keys()) + ["fireID"]), crs=str(settings.EPSG_CODE), geometry=[]
     )
     gdf = gdf.set_index("fireID")
 

--- a/fireatlas/FireGpkg_sfs.py
+++ b/fireatlas/FireGpkg_sfs.py
@@ -284,7 +284,7 @@ def make_sf_nfplist(allfires, t, regnm, fids):
                 df.columns = sfkeys
                 gdf_1f = gpd.GeoDataFrame(
                     df,
-                    crs="epsg:" + str(settings.EPSG_CODE),
+                    crs=str(settings.EPSG_CODE),
                     geometry=gpd.points_from_xy(df.x, df.y),
                 )
 

--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -876,7 +876,7 @@ def AFP_toprj(gdf):
     for CA may use WGS 84 / UTM zone 10N (epsg: 32610)
     for US may use US National Atlas Equal Area (epsg: 9311)"""
 
-    gdf = gdf.to_crs(epsg=settings.EPSG_CODE)
+    gdf = gdf.to_crs(crs=settings.EPSG_CODE)
     gdf["x"] = gdf.geometry.x
     gdf["y"] = gdf.geometry.y
     df = pd.DataFrame(gdf.drop(columns="geometry"))

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -162,8 +162,8 @@ def maybe_remove_static_sources(region: Region) -> Region:
     reg_df = gpd.GeoDataFrame.from_dict({"name":[region[0]], "geometry":[reg]}) # Put geometry into dataframe for join
     
     # ensure everything is in the same projection
-    global_flaring = global_flaring.set_crs("EPSG:" + str(settings.EPSG_CODE)) ## Translate to the user-input coordinate system
-    reg_df = reg_df.set_crs("EPSG:" + str(settings.EPSG_CODE))
+    global_flaring = global_flaring.set_crs(str(settings.EPSG_CODE)) ## Translate to the user-input coordinate system
+    reg_df = reg_df.set_crs(str(settings.EPSG_CODE))
     
     # Take the difference of points and region
     diff = gpd.tools.overlay(reg_df, global_flaring, how='difference')

--- a/fireatlas/FireObj.py
+++ b/fireatlas/FireObj.py
@@ -77,7 +77,7 @@ class Allfires:
                 "fireID",
                 "t",
             ],
-            crs=f"epsg:{settings.EPSG_CODE}",
+            crs=str(settings.EPSG_CODE),
             geometry="hull",
         )
         self.gdf = gdf.set_index(["fireID", "t"])


### PR DESCRIPTION
No longer assumes that CRS will be specified with an integer that corresponds to an EPSG code; now, it can be a string as well. Also, adds the projections used for global regions as "allowed" options, and adds a check to warn if the user is trying to use a non-projected coordinate system. 