### PR TITLE
Prioritize archive

### DIFF
--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -397,49 +397,53 @@ def read_VJ114IMGML(filepath: str):
     df : pandas.DataFrame
         monthly DataFrame containing standardized columns of VIIRS active fires
     """
-    usecols = [
-        "year",
-        "month",
-        "day",
-        "hh",
-        "mm",
-        "lon",
-        "lat",
-        "mask",
-        "line",
-        "sample",
-        "frp",
-    ]
 
-    df = pd.read_csv(
-        filepath,
-        dtype={col: "string" for col in ["year", "month", "day", "hh", "mm"]},
-        usecols=usecols,
-        skipinitialspace=True,
-    )
-    df["datetime"] = pd.to_datetime(
-        df["year"]
-        + "-"
-        + df["month"]
-        + "-"
-        + df["day"]
-        + " "
-        + df["hh"]
-        + ":"
-        + df["mm"],
-        format="%Y-%m-%d %H:%M",
-    )
-    df = df.rename(
-        columns={
-            "lat": "Lat",
-            "lon": "Lon",
-            "frp": "FRP",
-            "line": "Line",
-            "sample": "Sample",
-        }
-    )
-    df["DT"], df["DS"] = viirs_pixel_size(df["Sample"].values)
-    return df
+    # collection 2 data now uses the same format as for SNPP
+    return read_VNP14IMGML(filepath)
+
+    # usecols = [
+    #     "year",
+    #     "month",
+    #     "day",
+    #     "hh",
+    #     "mm",
+    #     "lon",
+    #     "lat",
+    #     "mask",
+    #     "line",
+    #     "sample",
+    #     "frp",
+    # ]
+
+    # df = pd.read_csv(
+    #     filepath,
+    #     dtype={col: "string" for col in ["year", "month", "day", "hh", "mm"]},
+    #     usecols=usecols,
+    #     skipinitialspace=True,
+    # )
+    # df["datetime"] = pd.to_datetime(
+    #     df["year"]
+    #     + "-"
+    #     + df["month"]
+    #     + "-"
+    #     + df["day"]
+    #     + " "
+    #     + df["hh"]
+    #     + ":"
+    #     + df["mm"],
+    #     format="%Y-%m-%d %H:%M",
+    # )
+    # df = df.rename(
+    #     columns={
+    #         "lat": "Lat",
+    #         "lon": "Lon",
+    #         "frp": "FRP",
+    #         "line": "Line",
+    #         "sample": "Sample",
+    #     }
+    # )
+    # df["DT"], df["DS"] = viirs_pixel_size(df["Sample"].values)
+    # return df
 
 
 def VJ114IMGTDL_filepath(t: TimeStep):

--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -232,10 +232,12 @@ def VNP14IMGML_filepath(t: TimeStep):
         "VIIRS",
         "VNP14IMGML",
     )
-
-    filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.C1.05.txt")
+    # prefers collection 2 version 3 (latest as of July 2025)
+    filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.C2.03.txt")
     if not settings.fs.exists(filepath):
         filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.C2.01.txt")
+    if not settings.fs.exists(filepath):
+        filepath = os.path.join(file_dir, f"VNP14IMGML.{year}{month:02}.C1.05.txt")
     if not settings.fs.exists(filepath):
         print("No data available for file", filepath)
         return
@@ -370,13 +372,15 @@ def VJ114IMGML_filepath(t: TimeStep):
     filepath : str
         Path to input data or None if file does not exist
     """
-    filepath = os.path.join(
+    year, month = t[0], t[1]
+
+    file_dir = os.path.join(
         settings.dirextdata,
         "VIIRS",
         "VJ114IMGML",
-        str(t[0]),
-        f"VJ114IMGML_{t[0]}{t[1]:02}.txt",
     )
+    # looks for collection 2 version 3 (latest as of July 2025)
+    filepath = os.path.join(file_dir, f"VJ114IMGML.{year}{month:02}.C2.03.txt")
     if not settings.fs.exists(filepath):
         print("No data available for file", filepath)
         return

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -204,10 +204,13 @@ def job_data_update_checker(client: Client, tst: TimeStep, ted: TimeStep):
 
         # gives list of timesteps for which there is no preprocessed file available
         timesteps = check_preprocessed_file(tst, ted, sat=sat, freq="NRT")
+
+        if len(timesteps) < 1: # no processing needed
+            return futures
         
         # there are no monthly arachive files for NOAA21 yet, so only check for SNPP and NOAA20
         if sat in ["SNPP", "NOAA20"]:
-            monthly_timesteps = list(set([(t[0], t[1]) for r in timesteps]))
+            monthly_timesteps = list(set([(t[0], t[1]) for t in timesteps]))
             monthly_filepaths = [monthly_filepath_func(t) for t in monthly_timesteps]
 
             # narrow down to the monthly filepaths and timesteps that actually exist 

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -199,30 +199,31 @@ def job_data_update_checker(client: Client, tst: TimeStep, ted: TimeStep):
             sp_filepath_func = FIRMS_VIIRS_NOAA20_SP_filepath
             nrt_filepath_func = FIRMS_VIIRS_NOAA20_NRT_filepath
         elif sat == "NOAA21":
-            # monthly_filepath_func = VJ24IMGML_filepath # @TODO
             sp_filepath_func = None 
             nrt_filepath_func = FIRMS_VIIRS_NOAA21_NRT_filepath
 
         # gives list of timesteps for which there is no preprocessed file available
         timesteps = check_preprocessed_file(tst, ted, sat=sat, freq="NRT")
+        
+        # there are no monthly arachive files for NOAA21 yet, so only check for SNPP and NOAA20
+        if sat in ["SNPP", "NOAA20"]:
+            monthly_timesteps = list(set([(t[0], t[1]) for r in timesteps]))
+            monthly_filepaths = [monthly_filepath_func(t) for t in monthly_timesteps]
 
-        monthly_timesteps = list(set([(t[0], t[1]) for r in timesteps]))
-        monthly_filepaths = [monthly_filepath_func(t) for t in monthly_timesteps]
+            # narrow down to the monthly filepaths and timesteps that actually exist 
+            indices = [i for i, f in enumerate(monthly_filepaths) if f is not None]
+            monthly_timesteps = [monthly_timesteps[i] for i in indices]
+            monthly_filepaths = [monthly_filepaths[i] for i in indices]
 
-        # narrow down to the monthly filepaths and timesteps that actually exist 
-        indices = [i for i, f in enumerate(monthly_filepaths) if f is not None]
-        monthly_timesteps = [monthly_timesteps[i] for i in indices]
-        monthly_filepaths = [monthly_filepaths[i] for i in indices]
+            # set up jobs to preprocess existing monthly files that need it
+            futures.extend(client.map(preprocess_input_file, monthly_filepaths))
 
-        # set up jobs to preprocess existing monthly files that need it
-        futures.extend(client.map(preprocess_input_file, monthly_filepaths))
+            # calculate any remaining missing timesteps not in monthly files
+            timesteps = [
+                t for t in timesteps if (t[0], t[1]) not in monthly_timesteps
+            ]
 
-        # calculate any remaining missing timesteps not in monthly files
-        missing_timesteps = [
-            t for t in timesteps if (t[0], t[1]) not in monthly_timesteps
-        ]
-
-        for t in missing_timesteps:
+        for t in timesteps:
             d = dt.datetime(t[0], t[1], t[2])
 
             if sp_start and (sp_start <= d <= sp_end):  

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -191,16 +191,38 @@ def job_data_update_checker(client: Client, tst: TimeStep, ted: TimeStep):
         sp_start, sp_end, nrt_start, nrt_end = get_FIRMS_data_availability(sat)
 
         if sat == "SNPP":
+            monthly_filepath_func = VNP14IMGML_filepath
             sp_filepath_func = FIRMS_VIIRS_SNPP_SP_filepath
             nrt_filepath_func = FIRMS_VIIRS_SNPP_NRT_filepath
         elif sat == "NOAA20":
+            monthly_filepath_func = VJ114IMGML_filepath
             sp_filepath_func = FIRMS_VIIRS_NOAA20_SP_filepath
             nrt_filepath_func = FIRMS_VIIRS_NOAA20_NRT_filepath
         elif sat == "NOAA21":
+            # monthly_filepath_func = VJ24IMGML_filepath # @TODO
             sp_filepath_func = None 
             nrt_filepath_func = FIRMS_VIIRS_NOAA21_NRT_filepath
 
-        for t in t_generator(tst, ted):
+        # gives list of timesteps for which there is no preprocessed file available
+        timesteps = check_preprocessed_file(tst, ted, sat=sat, freq="NRT")
+
+        monthly_timesteps = list(set([(t[0], t[1]) for r in timesteps]))
+        monthly_filepaths = [monthly_filepath_func(t) for t in monthly_timesteps]
+
+        # narrow down to the monthly filepaths and timesteps that actually exist 
+        indices = [i for i, f in enumerate(monthly_filepaths) if f is not None]
+        monthly_timesteps = [monthly_timesteps[i] for i in indices]
+        monthly_filepaths = [monthly_filepaths[i] for i in indices]
+
+        # set up jobs to preprocess existing monthly files that need it
+        futures.extend(client.map(preprocess_input_file, monthly_filepaths))
+
+        # calculate any remaining missing timesteps not in monthly files
+        missing_timesteps = [
+            t for t in timesteps if (t[0], t[1]) not in monthly_timesteps
+        ]
+
+        for t in missing_timesteps:
             d = dt.datetime(t[0], t[1], t[2])
 
             if sp_start and (sp_start <= d <= sp_end):  
@@ -208,6 +230,7 @@ def job_data_update_checker(client: Client, tst: TimeStep, ted: TimeStep):
                 # If not, download and overwrite old preprocessed file.
                 fp = sp_filepath_func(t)
                 if fs.exists(fp):
+
                     pfp = preprocessed_filename(t, sat, location=location)
                     if not fs.exists(pfp):
                         futures.append(client.submit(preprocess_input_file, fp))


### PR DESCRIPTION
When preprocessing input files with the level 3 VIIRS active fire detection monthly summaries (e.g. VNP14IMGML and VJ114IMGML- note that this product is not yet available for NOAA21), change `FireRunDaskCoordinator.job_data_update_checker()` to preferentially use monthly files downloaded to FEDSinput before trying to use daily files downloaded from the FIRMS database via API or downloading new records from FIRMS. 

While doing this, I updated several functions to reflect the latest file naming conventions. I also added logic to `FireIO.VNP14IMGML_filepath()` that looks first for collection 2 version 3 files, then for collection 2 version 1, then for version 1 collection 5, addressing #167.  