### PR TITLE
Cherry pick from Tess's PR: don't reset fids on new year, but check fid len

### DIFF
--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -465,6 +465,9 @@ def Fire_Forward_one_step(allfires, allpixels, tst, t, region, landcover):
     logger.info("--------------------")
     logger.info(f"Fire tracking at {t}")
 
+    if FireTime.isyearst(t):
+        allfires.check_fid_len(region[0])
+
     # 1. record existing active fire ids (before fire tracking at t)
     fids_ea = allfires.fids_active
 

--- a/fireatlas/FireObj.py
+++ b/fireatlas/FireObj.py
@@ -18,7 +18,7 @@ from fireatlas.FireTime import t2dt, dt2t, t_nb, t_dif
 from fireatlas.postprocess import read_allfires_gdf, read_allpixels
 from fireatlas.FireFuncs import set_ftype
 from fireatlas.FireGpkg_sfs import getdd as singlefire_getdd
-from fireatlas.FireIO import save_newyearfidmapping
+from fireatlas.FireLog import logger
 from fireatlas import FireVector
 from fireatlas import FireConsts
 from fireatlas import settings
@@ -311,36 +311,19 @@ class Allfires:
             []
         )  # a list of ids for fires invalidated at current time step
 
-    def newyear_reset(self, regnm):
-        """reset fire ids at the start of a new year"""
-        # re-id all active fires
-        newfires = {}
-        fidmapping = []
-        fids_keep = self.fids_active + self.fids_sleeper
-        for i, fid in enumerate(fids_keep):
-            newfires[i] = self.fires[fid]  # record new fireID and fire object
-            newfires[i].fireID = i  # also update fireID attribute of fire object
-            fidmapping.append((fid, i))
-        self.fires = newfires
-
-        # lastyearfires = {}
-        # fidmapping = []
-        # nfid = 0
-        # for f in self.activefires:
-        #     ofid = f.fireID
-        #     f.fireID = nfid
-        #     # lastyearfires.append(f)
-        #     lastyearfires[nfid] = f
-        #     fidmapping.append((ofid,nfid))
-        #     nfid += 1
-        # self.fires = lastyearfires
-
-        # clean heritages
-        self.heritages = []
-
-        # save the mapping table
-        if len(fidmapping) > 0:
-            save_newyearfidmapping(fidmapping, self.t[0], regnm)
+    def check_fid_len(self, regnm):
+        """
+        Throw a warning if any fireID is larger than 1e14
+        """
+        max_fid_len = 1e14
+        if (
+            any( x>= max_fid_len for x in self.fids_active) |
+            any(x>= max_fid_len for x in self.fids_sleeper)
+        ):
+            logger.warning(
+                f"WARNING: FireID is longer than {max_fid_len} in region {regnm}. "
+            )
+        return
 
     # functions to be run after tracking VIIRS active fire pixels at each time step
     def record_fids_change(


### PR DESCRIPTION
I had a lot of trouble testing #210 just because staging has moved on so much since it was opened, and there were a lot of merge conflicts. It ended up being easier to just create this new branch than to resolve the conflicts involved in rebasing the existing branch onto staging. 

I've lightly tested this and am satisfied that fireIDs don't reset on the new year rollover, and that it doesn't crash when working over into a new calendar year. 

@mccabete, could you please review and go ahead and merge this PR if it looks OK to you? Note that when compared to #210, I took out the setter for fireID as I couldn't see where that would be used with your new rollover approach. That was originally proposed with Lisa's PR, but then we changed how we were handling fids so I think it is not needed anymore. 


