### PR TITLE
Clarify CRS handling for region preprocessing

### DIFF
--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -967,7 +967,9 @@ def load_mcd64(year, xoff=0, yoff=0, xsize=None, ysize=None):
 
 
 def get_any_shp(filename):
-    """get shapefile of any region given the input file name
+    """get shapefile of any region given the input file name. 
+
+    Reprojects to geographic coordinate system (EPSG:4326) from input CRS. 
 
     Parameters
     ----------
@@ -1022,7 +1024,7 @@ def get_reg_shp(reg):
     if isinstance(reg, shapely.geometry.base.BaseGeometry):
         shp_Reg = reg
     elif isinstance(reg, str):
-        print(f'Running get_any_shp for {reg}')
+        logger.info(f'Running get_any_shp for {reg}')
         shp_Reg = get_any_shp(reg)
         if shp_Reg is None:
             raise Exception('Specified input did not produce valid geometry.')

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -140,7 +140,11 @@ def maybe_remove_static_sources(region: Region) -> Region:
     Returns
     -------
     region : region obj
-        A region that is the difference between the user-supplied region and the points identified as static flaring/gas according to the source. Creates a "swiss cheese"- like region, with negative space where there were points, with a buffer around points determined by "remove_static_sources_buffer". 
+        A region that is the difference between the user-supplied region and the points identified as static 
+        flaring/gas according to the source. Creates a "swiss cheese"- like region, with negative space where there 
+        were points, with a buffer around points determined by "remove_static_sources_buffer". 
+
+        Filters and returns input geometry in geographic coordinate system (EPSG:4326).  
     """
     if not settings.remove_static_sources:
         # should make sure region[1] is a geometry
@@ -153,17 +157,17 @@ def maybe_remove_static_sources(region: Region) -> Region:
     global_flaring = global_flaring.drop_duplicates()
     global_flaring = global_flaring[0:(len(global_flaring.id_key_2017) - 1)]
 
-    global_flaring = gpd.GeoDataFrame(global_flaring, geometry=gpd.points_from_xy(global_flaring.Longitude, global_flaring.Latitude)) # Convert to point geometries
+    global_flaring = gpd.GeoDataFrame(
+        global_flaring, 
+        geometry=gpd.points_from_xy(global_flaring.Longitude, global_flaring.Latitude),
+        crs="EPSG:4326"
+    ) # Convert to point geometries
     global_flaring["buffer_geometry"] = global_flaring.buffer(settings.remove_static_sources_buffer)
     global_flaring = global_flaring.set_geometry(col = "buffer_geometry")
     
     # get region geometry
     reg = FireIO.get_reg_shp(region[1])
-    reg_df = gpd.GeoDataFrame.from_dict({"name":[region[0]], "geometry":[reg]}) # Put geometry into dataframe for join
-    
-    # ensure everything is in the same projection
-    global_flaring = global_flaring.set_crs(str(settings.EPSG_CODE)) ## Translate to the user-input coordinate system
-    reg_df = reg_df.set_crs(str(settings.EPSG_CODE))
+    reg_df = gpd.GeoDataFrame.from_dict({"name":[region[0]], "geometry":[reg]}, crs="EPSG:4326") # Put geometry into dataframe for join
     
     # Take the difference of points and region
     diff = gpd.tools.overlay(reg_df, global_flaring, how='difference')


### PR DESCRIPTION
The following lines were setting the CRS to the user input CRS, but neither the static sources nor the input region were ever actually reprojected into the user input CRS. The static sources come in geographic coordinates, and the input region is either defined in geographic coords (as a lat/lon bbox) or reprojected into EPSG:4326 in `FireIO.get_any_shp` if it is passed as a filename that points to a shapefile. So, setting the CRS of these dataframes to `settings.EPSG_CODE` without actually reprojecting them is misleading. 

```
# ensure everything is in the same projection
global_flaring = global_flaring.set_crs(str(settings.EPSG_CODE)) ## Translate to the user-input coordinate system
reg_df = reg_df.set_crs(str(settings.EPSG_CODE))
```