### PR TITLE
Missing file handling

### DIFF
--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -209,7 +209,7 @@ def job_data_update_checker(client: Client, tst: TimeStep, ted: TimeStep):
         if len(timesteps) < 1: # no processing needed
             return futures
         
-        # there are no monthly arachive files for NOAA21 yet, so only check for SNPP and NOAA20
+        # there are no monthly archive files for NOAA21 yet, so only check for SNPP and NOAA20
         if sat in ["SNPP", "NOAA20"]:
             monthly_timesteps = list(set([(t[0], t[1]) for t in timesteps]))
             monthly_filepaths = [monthly_filepath_func(t) for t in monthly_timesteps]

--- a/fireatlas/preprocess.py
+++ b/fireatlas/preprocess.py
@@ -207,7 +207,7 @@ def check_preprocessed_file(
     if freq == "monthly":
         return list(set([(t[0], t[1]) for t in needs_processing]))
     else:
-        return list(set([(t[0], t[1], t[2]) for t in needs_processing]))
+        return list(set([(t[0], t[1], t[2], t[3]) for t in needs_processing]))
 
 
 @timed

--- a/fireatlas/preprocess.py
+++ b/fireatlas/preprocess.py
@@ -374,7 +374,7 @@ def preprocess_region_t(
             try:
                 dfs.append(read_preprocessed_input(t, sat=sat, location=read_location))
             except (FileNotFoundError, pd.errors.EmptyDataError) as e:
-                logger.info(f"{sat} file not available at {t=}: '{str(e)}'")
+                logger.info(f"{sat} file or data not available at {t=}: '{str(e)}'")
         if len(dfs) == 0:
             raise ValueError(f"NOAA20, NOAA21, and SNPP files are not available for {t=}")
         else:

--- a/fireatlas/preprocess.py
+++ b/fireatlas/preprocess.py
@@ -290,19 +290,20 @@ def preprocess_input_file(filepath: str):
 
     for day, data in gb:
         for ampm in ["AM", "PM"]:
-            time_filtered_df = data.loc[df["ampm"] == ampm]
-
-            output_filepath = preprocessed_filename(
-                (day.year, day.month, day.day, ampm), sat=sat, location="local"
-            )
-
-            # make nested path if necessary
-            os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
-
-            # save active pixels at this time step (day and ampm filter)
-            time_filtered_df.to_csv(output_filepath, index=False)
-
-            output_paths.append(output_filepath)
+            time_filtered_df = data.loc[data["ampm"] == ampm]
+            
+            if len(time_filtered_df)>0: # if there's data for this ampm condition, write it out
+                output_filepath = preprocessed_filename(
+                    (day.year, day.month, day.day, ampm), sat=sat, location="local"
+                )
+    
+                # make nested path if necessary
+                os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
+    
+                # save active pixels at this time step (day and ampm filter)
+                time_filtered_df.to_csv(output_filepath, index=False)
+    
+                output_paths.append(output_filepath)
 
     return output_paths
 
@@ -323,8 +324,10 @@ def read_preprocessed_input(
     sat: Literal["NOAA20", "NOAA21", "SNPP"],
     location: Location = None,
 ):
+    
     filename = preprocessed_filename(t, sat=sat, location=location)
     df = pd.read_csv(filename)
+
     return df
 
 
@@ -370,7 +373,7 @@ def preprocess_region_t(
         for sat in ["SNPP", "NOAA20", "NOAA21"]:
             try:
                 dfs.append(read_preprocessed_input(t, sat=sat, location=read_location))
-            except FileNotFoundError as e:
+            except (FileNotFoundError, pd.errors.EmptyDataError) as e:
                 logger.info(f"{sat} file not available at {t=}: '{str(e)}'")
         if len(dfs) == 0:
             raise ValueError(f"NOAA20, NOAA21, and SNPP files are not available for {t=}")


### PR DESCRIPTION
Fixes the ongoing issues prohibiting global runs within staging environment. I noticed a few weird things happening: 

#### What changed?

1. ```shared-buckets/zbecker/FEDSstaging/FEDSpreprocessed/NOAA20/20250406_AM.txt``` existed as a file but was completely empty. A rerun of the preprocessing data rewrites this file in its correct and expected form. I'm still not sure why the original error occurred to begin with, but now we can handle (and log) this error should it occur again. I also added in an ```if``` clause which should prevent these empty files being written in the first place. 
2. Fixed what appears to be a typo - ```time_filtered_df = data.loc[df["ampm"] == ampm]``` is now ```time_filtered_df = data.loc[data["ampm"] == ampm]```. 
3. `check_preprocessed_file` was only returning the first three items in `t`. This was causing an error in `preprocessed_filename`, which requires a length 4 tuple to run. `check_preprocessed_file` now returns all four items. 


#### What's been done to validate the outputs? 

1. Previously failing from-scratch ADE runs (i.e. all preprocessed VIIRS data are deleted and reprocessed) have successfully completed for the previously problematic time periods. I repeated this four times. Given the problematic file is no longer empty, the added exception handling has not needed to be utilized, but I had previously tested this one time prior. 
2. The resulting `largefire_perimeter.fgb` passed a quick "once-over" visual inspection. 
3. Tests have run and passed, **except** for two new ones that may be more related to a version issue: 

```FAILED tests/test_io.py::test_gpd_read_csv[valid.csv-False-None] - fiona._err.CPLE_AppDefinedError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version 'GLIBCXX_3.4.30' not found (required by /opt/conda/envs/pangeo/lib/gdalplugins/../libgdal.so.35)```

```FAILED tests/test_io.py::test_gpd_read_static_source[valid.csv-False-None] - fiona._err.CPLE_AppDefinedError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version 'GLIBCXX_3.4.30' not found (required by /opt/conda/envs/pangeo/lib/gdalplugins/../libgdal.so.35)```

#### Recap

Squashed a few bugs and the reruns seem to be going OK. Two new tests failed, which is likely worth looking a bit more into. 