### PR TITLE
Gdf speedups

### DIFF
--- a/fireatlas/FireObj.py
+++ b/fireatlas/FireObj.py
@@ -154,25 +154,26 @@ class Allfires:
             if (fid, dt) in self.gdf.index:
                 raise ValueError(f"Error writing gdf: {fid} already at {self.t}")
 
-            row = {"fid": fid, "dt": dt} # get index levels  
+            row = {"fireID": fid, "t": dt} # get index levels  
             for k, tp in dd.items(): 
                 val = getattr(f, k)
                 row[k] = t2dt(val) if tp == "datetime64[ns]" else val
             new_rows.append(row)
         
-        # create a new gdf with updated rows 
-        gdf_updates = gpd.GeoDataFrame(
-            new_rows,
-            geometry="hull", 
-            crs=settings.EPSG_CODE
-        ).set_index(["fid", "dt"])
+        if len(new_rows) > 0: 
+            # create a new gdf with updated rows 
+            gdf_updates = gpd.GeoDataFrame(
+                new_rows,
+                geometry="hull", 
+                crs=settings.EPSG_CODE
+            ).set_index(["fireID", "t"])
 
-        # ensure/cast types once 
-        for k, tp in dd.items(): 
-            gdf_updates[k] = gdf_updates[k].astype(tp)
+            # ensure/cast types once 
+            for k, tp in dd.items(): 
+                gdf_updates[k] = gdf_updates[k].astype(tp)
 
-        # append updated rows to existing dataframe in one batch- much faster than looping through 
-        self.gdf = pd.concat([self.gdf, gdf_updates], axis=0)
+            # append updated rows to existing dataframe in one batch- much faster than looping through 
+            self.gdf = pd.concat([self.gdf, gdf_updates], axis=0)
 
         for h0, h1 in self.heritages:
             if h0 in self.gdf.index:
@@ -540,11 +541,12 @@ class Fire:
             & (self.allpixels["t"] == t2dt(self.t))
         ]
 
+    # @TODO can we call this less? 
     @property
     def newlocs(self):
         """List of new fire pixels locations (lat,lon)"""
         return self.newpixels[["x", "y"]].values
-
+    # @TODO can we call THIS less? 
     @property
     def newlocs_geo(self):
         """List of new fire pixels locations (lat,lon)"""
@@ -556,6 +558,15 @@ class Fire:
         mp = MultiPoint(self.newlocs)
         return mp
 
+    # @TODO can we call this less? 
+    @property
+    def newpixelatts(self):
+        """List of new fire pixels attributes"""
+        return [
+            (p.Lon, p.Lat, p.FRP, p.DS, p.DT, p.datetime, p.ampm, p.Sat)
+            for p in self.newpixels
+        ]
+    # @TODO duplicate of above? 
     @property
     def newpixelatts(self):
         """List of new fire pixels attributes"""
@@ -564,14 +575,7 @@ class Fire:
             for p in self.newpixels
         ]
 
-    @property
-    def newpixelatts(self):
-        """List of new fire pixels attributes"""
-        return [
-            (p.Lon, p.Lat, p.FRP, p.DS, p.DT, p.datetime, p.ampm, p.Sat)
-            for p in self.newpixels
-        ]
-
+    # @TODO can we call this less? 
     @property
     def n_newpixels(self):
         """Total number of new fire pixels"""

--- a/fireatlas/FireObj.py
+++ b/fireatlas/FireObj.py
@@ -7,7 +7,7 @@ FOUR LAYERS OF OBJECTS
     c. Cluster:   the class of active fire pixel cluster (only for supporting)
     d. FirePixel: the class of an active fire pixel
 """
-
+import pandas as pd
 import geopandas as gpd
 from datetime import date, timedelta
 from shapely.geometry import MultiLineString, MultiPoint
@@ -134,21 +134,45 @@ class Allfires:
 
     @timed
     def update_gdf(self):
+        """
+        The idea here is that we need to update self.gdf with the latest
+        attributes for each burning fire, as those may have changed 
+        as we progressed through the last timestep. 
+
+        But, instead of looping through those and writing each cell one at a 
+        time, like the original code did, here we are going to make a new dataframe 
+        with what each active row should be updated to, then drop the old versions 
+        of those rows and append the new versions so that we only mutate the dataframe once. 
+        """
         dd = singlefire_getdd("all")
         dt = t2dt(self.t)
 
+        new_rows = [] # collect row dicts for a batch update 
+
+        # all active fires need to be updated 
         for fid, f in self.burningfires.items():
             if (fid, dt) in self.gdf.index:
                 raise ValueError(f"Error writing gdf: {fid} already at {self.t}")
 
-            for k, tp in dd.items():
-                if tp == "datetime64[ns]":
-                    self.gdf.loc[(fid, dt), k] = t2dt(getattr(f, k))
-                else:
-                    self.gdf.loc[(fid, dt), k] = getattr(f, k)
+            row = {"fid": fid, "dt": dt} # get index levels  
+            for k, tp in dd.items(): 
+                val = getattr(f, k)
+                row[k] = t2dt(val) if tp == "datetime64[ns]" else val
+            new_rows.append(row)
+        
+        # create a new gdf with updated rows 
+        gdf_updates = gpd.GeoDataFrame(
+            new_rows,
+            geometry="hull", 
+            crs=settings.EPSG_CODE
+        ).set_index(["fid", "dt"])
 
-        for k, tp in dd.items():
-            self.gdf[k] = self.gdf[k].astype(tp)
+        # ensure/cast types once 
+        for k, tp in dd.items(): 
+            gdf_updates[k] = gdf_updates[k].astype(tp)
+
+        # append updated rows to existing dataframe in one batch- much faster than looping through 
+        self.gdf = pd.concat([self.gdf, gdf_updates], axis=0)
 
         for h0, h1 in self.heritages:
             if h0 in self.gdf.index:


### PR DESCRIPTION
Major performance improvements! No API changes. 

Experimenting with running FEDS on all of Africa, since that is the global region with the highest density of detections, I found that due to differences in the underlying distribution of the input data, we had different performance bottlenecks here than we do for North America. Specifically, we were spending ~60% of our compute time in the `Allfires.update_gdf()` function when running on my Africa benchmarks. 

I refactored the internals of this function without changing the ultimate outputs. We used to be essentially looping over every cell in the allfires dataframe and mutating them one at a time, which is a pretty inefficient data access pattern for Pandas. Instead, we now collect all the rows that need to be updated into a list of dicts. Then, at the end, we can do a one-time creation of a new dataframe and append that to the existing one. This is so much faster that this function now takes <1% of compute time, down from 60%. 

Also, the tests I wrote last summer caught a sneaky bug right before I pushed, so that was satisfying and saved a ton of developer time. 