### PR TITLE
add nifc conditional for veda export cols

### DIFF
--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -2089,6 +2089,11 @@ def copy_from_local_to_veda_s3(local_filepath: str, regnm: str, fs: s3fs.S3FileS
             "low_confidence_grouping",
             "geometry",
         ]
+
+        if settings.DO_NIFC_MATCHING:
+            nifc_cols = ['NIFC_DiscoveryDT','NIFC_IncidentName','NIFC_IRWINID','NIFC_IncidentType']
+            select_cols = select_cols + nifc_cols
+        
     elif "lf_fireline" in from_maap_s3_path:
         select_cols = ["fireID", "t", "primarykey", "region", "geometry"]
     elif "lf_newfirepix" in from_maap_s3_path:


### PR DESCRIPTION
Hoping this is pretty straightforward. [Line 2124](https://github.com/Earth-Information-System/fireatlas/blob/7fa9e401dea7ce770d75ec9729ba47d23df78b83/fireatlas/FireIO.py#L2124) in `FireIO` is where `select_cols` is used to isolate which columns make it over to VEDA: 

```gdf[select_cols].to_file(local_tmp_filepath, driver="GPKG")```

I added the conditional for combined largefire data _only_: 

```
# for combine_largefire
elif "lf_perimeter" in from_maap_s3_path:
    select_cols = [
        "n_pixels",
        "n_newpixels",
        "farea",
        "fperim",
        "flinelen",
        "duration",
        "pixden",
        "meanFRP",
        "t",
        "fireID",
        "primarykey",
        "region",
        "geom_counts",
        "low_confidence_grouping",
        "geometry",
    ]

    ##### NEW CONDITIONAL ####
    if settings.DO_NIFC_MATCHING:
        nifc_cols = ['NIFC_DiscoveryDT','NIFC_IncidentName','NIFC_IRWINID','NIFC_IncidentType']
        select_cols = select_cols + nifc_cols
```

This just concatenates these other NIFC-specific columns to the existing list.

NOTE: This has **not** been tested. Due to the current hesitancy to send anything to VEDA that still in development, I haven't flipped the switch to try the logic. Open to strategizing how to go about the testing, and maybe this can come into play when we coordinate with Dev Seed. 