### PR TITLE
add option to avoid dask for large postprocessing tasks

### DIFF
--- a/fireatlas/FireConsts.py
+++ b/fireatlas/FireConsts.py
@@ -186,6 +186,10 @@ class Settings(BaseSettings):
     )
     N_DASK_WORKERS: int = Field(6, description="How many dask workers to use for Run.")
 
+    DEPARALLELIZE_POSTPROCESS: bool = Field(
+        False, description="whether to avoid dask for postprocessing in case of worker memory errors"
+    )
+
     DO_NIFC_MATCHING: bool = Field(
         False, 
         description="If True, reads from the NIFC incident database for current "

--- a/fireatlas/postprocess.py
+++ b/fireatlas/postprocess.py
@@ -411,10 +411,11 @@ def save_large_fires_layers(allfires_gdf, region, large_fires, tst, ted, client=
     futures = []
     processed_gdfs = []
     for fid, data in gdf[gdf["fireID"].isin(large_fires)].groupby("fireID"):
-        if client:
-            futures.append(client.submit(merge_and_save_fire, data, fid))
-        else:
+        if settings.DEPARALLELIZE_POSTPROCESS == True:
             processed_gdfs.append(merge_and_save_fire(data, fid))
+        else:
+            futures.append(client.submit(merge_and_save_fire, data, fid))
+
     if futures:
         processed_gdfs = client.gather(futures)
 


### PR DESCRIPTION
Addresses issue when memory-intensive `merge_and_save_fire` call exceeds individual dask worker memory. 