### PR TITLE
add "version" to NRT columns, handle all known duplicate point scenarios

### DIFF
--- a/fireatlas/FireIO.py
+++ b/fireatlas/FireIO.py
@@ -709,7 +709,8 @@ def read_FIRMS_VIIRS_SP(filepath: str):
         "confidence",
         "frp", 
         "daynight",
-        "type"
+        "type",
+        "version"
     ]
 
     df = pd.read_csv(
@@ -766,7 +767,8 @@ def read_FIRMS_VIIRS_NRT(filepath: str):
         "acq_time", 
         "confidence",
         "frp", 
-        "daynight"
+        "daynight",
+        "version"
     ]
 
     df = pd.read_csv(

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -177,8 +177,21 @@ def maybe_remove_static_sources(region: Region) -> Region:
     region = (diff.name[0], diff.geometry[0])
     return region
 
-def flag_duplicate_pixels(allpixels):
-        
+def flag_and_remove_duplicate_pixels(allpixels):
+    """ Identify and correct duplicated VIIRS pixels due to identical points 
+        being processed by multiple NRT algorithm versions. Dropping logic
+        favors NRT over URT and 2.X over 2.0.
+
+    Parameters
+    ----------
+    allpixels : the current allpixels object. 
+
+    Returns
+    -------
+    region : allpixels
+        The same allpixels object as before, either unmodified if no 
+        duplicated points are detected or with duplicates dropped.  
+    """
     logger.info('Searching for duplicated points...')
     coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance
     duplicated_coords = coord_counts[coord_counts > 1] 
@@ -209,12 +222,31 @@ def flag_duplicate_pixels(allpixels):
         return allpixels
 
 def adjust_coincident_pixels(allpixels):
+    """ Identify and correct coincident VIIRS pixels. These observations 
+    represent valid data, where two or more sensors return identical (coincident) 
+    locations at separate times. These points should be preserved, but their
+    identical lat/lon values mean the hull functions would fail. This function
+    looks for any coincident pairs, and slighly adjusts them in space
+    to resolve the error. 
 
-    coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance again
+    NOTE: This functions assumes the a projected coordinate system is expressed in meters. 
+    Unexpected behavior may occur if using a geographic coordinate system is used. 
+
+    Parameters
+    ----------
+    allpixels : the current allpixels object. 
+
+    Returns
+    -------
+    region : allpixels
+        The same allpixels object as before, either unmodified if no 
+        coincident points are detected or with those points adjusted.  
+    """
+    coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance
     duplicated_coords = coord_counts[coord_counts > 1] 
     
     if len(duplicated_coords)==0:
-        logger.info('No coincident points detected. Proceeding to next step...')
+        logger.info('No coincident points detected. Proceeding to next step with no action taken...')
         return allpixels
     
     if len(duplicated_coords)>0:
@@ -238,7 +270,7 @@ def adjust_coincident_pixels(allpixels):
             # Store original coordinates before applying jitter
             original_coords = allpixels.loc[duplicate_indices, ["y", "x"]].values
 
-            # Generate jitter for each duplicate record - THIS ASSUMES YOUR LINEAR COORD IS IN METERS
+            # Generate jitter for each duplicate record - note this value is on the order of 10^-6 units (should be meters). 
             jitter = np.random.normal(0, 1e-6, (len(duplicate_indices), 2))
 
             # Apply jitter to y and x columns
@@ -672,7 +704,7 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
         allpixels = pd.concat(non_empty_dfs)
 
     if settings.FIRE_NRT == True:
-        allpixels = flag_duplicate_pixels(allpixels)
+        allpixels = flag_and_remove_duplicate_pixels(allpixels)
 
     # look for coincident pixels where two satellites have the exact lat/lon pair
     all_pixels = adjust_coincident_pixels(allpixels)

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -176,7 +176,97 @@ def maybe_remove_static_sources(region: Region) -> Region:
     
     region = (diff.name[0], diff.geometry[0])
     return region
+
+def flag_duplicate_pixels(allpixels):
+        
+    logger.info('Searching for duplicated points...')
+    coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance
+    duplicated_coords = coord_counts[coord_counts > 1] 
+
+    if len(duplicated_coords)==0:
+        logger.info('None detected. Proceeding to next step...')
+        return allpixels
     
+    elif len(duplicated_coords)>0:
+        logger.warning(f'There are {len(duplicated_coords)} potentially duplicated coordinate pairs')
+        pre_drop_length = len(allpixels)
+
+        # make temporary helper columns to assist with sorting and dropping duplicates
+        allpixels[['version_number', 'version_category']] = allpixels['version'].str.extract(r'([0-9.]+)([A-Za-z]+)')
+        allpixels = allpixels.sort_values(['version_category','version_number'],ascending=[True,False]) # rule: NRT is before URT, 2.1 is before 2.0, 
+        allpixels = allpixels.drop_duplicates(subset=['y','x','Sat','datetime'],keep='first') # handle cases where only version differs
+        logger.info(f'Removed {(pre_drop_length - len(allpixels))} duplicated points for the same sensor and time after inspection.')
+
+        # remove helper columns when done
+        allpixels = allpixels.drop(['version_number', 'version_category'],axis=1)
+        
+        coord_counts_recheck = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance again
+        duplicated_coords_after_recheck = coord_counts_recheck[coord_counts_recheck > 1] 
+        
+        if len(duplicated_coords_after_recheck)>0:
+            logger.warning(f'There are still {len(duplicated_coords_after_recheck)} potentially duplicated coordinate pairs')
+            
+        return allpixels
+
+def adjust_coincident_pixels(allpixels):
+
+    coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance again
+    duplicated_coords = coord_counts[coord_counts > 1] 
+    
+    if len(duplicated_coords)==0:
+        logger.info('No coincident points detected. Proceeding to next step...')
+        return allpixels
+    
+    if len(duplicated_coords)>0:
+        logger.warning(f'There are {len(duplicated_coords)} potentially coincident coordinate pairs')
+        
+        # Display detailed information about remaining duplicates
+        logger.info("Details of duplicate coordinate pairs:")
+        for (y, x), count in duplicated_coords.items():
+            logger.info(f"  Coordinate ({y:.8f}, {x:.8f}) appears {count} times:")
+
+            # Get all records for this coordinate pair and display specific columns
+            duplicate_records = allpixels[(allpixels["y"] == y) & (allpixels["x"] == x)]
+
+            for idx, row in duplicate_records.iterrows():
+                logger.info(f"    Y: {row['y']:.8f} | X: {row['x']:.8f} | Sat: {row['Sat']} | DateTime: {row['datetime']} | Version: {row['version']}")
+            
+            # Apply jitter to all records with this duplicate coordinate pair
+            mask = (allpixels["y"] == y) & (allpixels["x"] == x)
+            duplicate_indices = allpixels[mask].index
+
+            # Store original coordinates before applying jitter
+            original_coords = allpixels.loc[duplicate_indices, ["y", "x"]].values
+
+            # Generate jitter for each duplicate record - THIS ASSUMES YOUR LINEAR COORD IS IN METERS
+            jitter = np.random.normal(0, 1e-6, (len(duplicate_indices), 2))
+
+            # Apply jitter to y and x columns
+            allpixels.loc[duplicate_indices, "y"] = allpixels.loc[duplicate_indices, "y"] + jitter[:, 0]
+            allpixels.loc[duplicate_indices, "x"] = allpixels.loc[duplicate_indices, "x"] + jitter[:, 1]
+
+            # Log the before/after differences
+            logger.info(f"    Applied jitter to {len(duplicate_indices)} records:")
+            for i, idx in enumerate(duplicate_indices):
+                orig_y, orig_x = original_coords[i]
+                new_y = allpixels.loc[idx, "y"]
+                new_x = allpixels.loc[idx, "x"]
+                diff_y = new_y - orig_y
+                diff_x = new_x - orig_x
+
+                logger.info(f"      ({orig_y:.8f}, {orig_x:.8f}) -> ({new_y:.8f}, {new_x:.8f}) | Diff: ({diff_y:.2e}, {diff_x:.2e})")
+
+        # Verify that duplicates are resolved
+        final_coord_counts = allpixels.groupby(["y", "x"]).size()
+        final_duplicated_coords = final_coord_counts[final_coord_counts > 1]
+
+        if len(final_duplicated_coords) == 0:
+            logger.info("Successfully resolved coincident coordinates with jittering")
+        else:
+            logger.warning(f"Still have {len(final_duplicated_coords)} duplicate coordinates after jittering - this should not happen!")
+            
+        return allpixels
+
 
 @timed
 def Fire_expand_rtree(allfires, allpixels, tpixels, fids_ea, landcover):
@@ -581,80 +671,11 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
     else:
         allpixels = pd.concat(non_empty_dfs)
 
-    ###########################################################################
-    ######## HANDLE CASES WHERE NRT DATA HAS DUPLICATE LAT/LON ENTRIES ########
-    ###########################################################################
-        
-    if settings.FIRE_NRT == True: 
-        logger.info('Searching for duplicated points...')
-        coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance
-        duplicated_coords = coord_counts[coord_counts > 1] 
-        
-        if len(duplicated_coords)>0: # check to see there are any duplicates
-            logger.warning(f'There are {len(duplicated_coords)} potentially duplicated coordinate pairs')
-            pre_drop_length = len(allpixels)
+    if settings.FIRE_NRT == True:
+        allpixels = flag_duplicate_pixels(allpixels)
 
-            # make temporary helper columns to help with sorting and dropping duplicates
-            allpixels[['version_number', 'version_category']] = allpixels['version'].str.extract(r'([0-9.]+)([A-Za-z]+)')
-            allpixels = allpixels.sort_values(['version_category','version_number'],ascending=[True,False]) # rule: NRT is before URT, 2.1 is before 2.0, 
-            allpixels = allpixels.drop_duplicates(subset=['y','x','Sat','datetime'],keep='first') # handle cases where only version differs
-            logger.info(f'Removed {(pre_drop_length - len(allpixels))} duplicated points for the same sensor and time after inspection.')
-
-            # remove helper columns when done
-            allpixels = allpixels.drop(['version_number', 'version_category'],axis=1)
-            
-            coord_counts_recheck = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance again
-            duplicated_coords_after_recheck = coord_counts_recheck[coord_counts_recheck > 1] 
-            if len(duplicated_coords_after_recheck)>0:
-                logger.warning(f'There are still {len(duplicated_coords_after_recheck)} potentially duplicated coordinate pairs')
-                
-                # Display detailed information about remaining duplicates
-                logger.info("Details of remaining duplicate coordinate pairs:")
-                for (y, x), count in duplicated_coords_after_recheck.items():
-                    logger.info(f"  Coordinate ({y:.8f}, {x:.8f}) appears {count} times:")
-                    
-                    # Get all records for this coordinate pair and display specific columns
-                    duplicate_records = allpixels[(allpixels["y"] == y) & (allpixels["x"] == x)]
-                    
-                    for idx, row in duplicate_records.iterrows():
-                        logger.info(f"    Y: {row['y']:.8f} | X: {row['x']:.8f} | Sat: {row['Sat']} | DateTime: {row['datetime']} | Version: {row['version']}")
-                    # Apply jitter to all records with this duplicate coordinate pair
-                    mask = (allpixels["y"] == y) & (allpixels["x"] == x)
-                    duplicate_indices = allpixels[mask].index
-
-                    # Store original coordinates before jittering
-                    original_coords = allpixels.loc[duplicate_indices, ["y", "x"]].values
-                    
-                    # Generate jitter for each duplicate record
-                    jitter = np.random.normal(0, 1e-6, (len(duplicate_indices), 2))
-                    
-                    # Apply jitter to y and x columns
-                    allpixels.loc[duplicate_indices, "y"] = allpixels.loc[duplicate_indices, "y"] + jitter[:, 0]
-                    allpixels.loc[duplicate_indices, "x"] = allpixels.loc[duplicate_indices, "x"] + jitter[:, 1]
-
-                    # Log the before/after differences
-                    logger.info(f"    Applied jitter to {len(duplicate_indices)} records:")
-                    for i, idx in enumerate(duplicate_indices):
-                        orig_y, orig_x = original_coords[i]
-                        new_y = allpixels.loc[idx, "y"]
-                        new_x = allpixels.loc[idx, "x"]
-                        diff_y = new_y - orig_y
-                        diff_x = new_x - orig_x
-                        
-                        logger.info(f"      ({orig_y:.8f}, {orig_x:.8f}) -> ({new_y:.8f}, {new_x:.8f}) | Diff: ({diff_y:.2e}, {diff_x:.2e})")
-                
-                # Verify that duplicates are resolved
-                final_coord_counts = allpixels.groupby(["y", "x"]).size()
-                final_duplicated_coords = final_coord_counts[final_coord_counts > 1]
-                
-                if len(final_duplicated_coords) == 0:
-                    logger.info("Successfully resolved all remaining duplicate coordinates with jittering")
-                else:
-                    logger.warning(f"Still have {len(final_duplicated_coords)} duplicate coordinates after jittering - this should not happen!")
-
-    ###########################################################################
-    ############################## END ########################################
-    ###########################################################################
+    # look for coincident pixels where two satellites have the exact lat/lon pair
+    all_pixels = adjust_coincident_pixels(allpixels)
 
     allpixels["fid"] = -1
     allpixels["in_fline"] = None

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -708,7 +708,7 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
 
     # Look for also rare case where two satellites have the exact lat/lon pair at different times.
     # This is for both NRT and archival runs
-    all_pixels = adjust_coincident_pixels(allpixels)
+    allpixels = adjust_coincident_pixels(allpixels)
 
     allpixels["fid"] = -1
     allpixels["in_fline"] = None

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -19,6 +19,7 @@ Modules required
 """
 import time
 import os
+import numpy as np
 import geopandas as gpd
 import pandas as pd
 import collections
@@ -579,6 +580,81 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
         allpixels = list_of_allpixels[0]
     else:
         allpixels = pd.concat(non_empty_dfs)
+
+    ###########################################################################
+    ######## HANDLE CASES WHERE NRT DATA HAS DUPLICATE LAT/LON ENTRIES ########
+    ###########################################################################
+        
+    if settings.FIRE_NRT == True: 
+        logger.info('Searching for duplicated points...')
+        coord_counts = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance
+        duplicated_coords = coord_counts[coord_counts > 1] 
+        
+        if len(duplicated_coords)>0: # check to see there are any duplicates
+            logger.warning(f'There are {len(duplicated_coords)} potentially duplicated coordinate pairs')
+            pre_drop_length = len(allpixels)
+
+            # make temporary helper columns to help with sorting and dropping duplicates
+            allpixels[['version_number', 'version_category']] = allpixels['version'].str.extract(r'([0-9.]+)([A-Za-z]+)')
+            allpixels = allpixels.sort_values(['version_category','version_number'],ascending=[True,False]) # rule: NRT is before URT, 2.1 is before 2.0, 
+            allpixels = allpixels.drop_duplicates(subset=['y','x','Sat','datetime'],keep='first') # handle cases where only version differs
+            logger.info(f'Removed {(pre_drop_length - len(allpixels))} duplicated points for the same sensor and time after inspection.')
+
+            # remove helper columns when done
+            allpixels = allpixels.drop(['version_number', 'version_category'],axis=1)
+            
+            coord_counts_recheck = allpixels.groupby(["y", "x"]).size() # count each lat/lon instance again
+            duplicated_coords_after_recheck = coord_counts_recheck[coord_counts_recheck > 1] 
+            if len(duplicated_coords_after_recheck)>0:
+                logger.warning(f'There are still {len(duplicated_coords_after_recheck)} potentially duplicated coordinate pairs')
+                
+                # Display detailed information about remaining duplicates
+                logger.info("Details of remaining duplicate coordinate pairs:")
+                for (y, x), count in duplicated_coords_after_recheck.items():
+                    logger.info(f"  Coordinate ({y:.8f}, {x:.8f}) appears {count} times:")
+                    
+                    # Get all records for this coordinate pair and display specific columns
+                    duplicate_records = allpixels[(allpixels["y"] == y) & (allpixels["x"] == x)]
+                    
+                    for idx, row in duplicate_records.iterrows():
+                        logger.info(f"    Y: {row['y']:.8f} | X: {row['x']:.8f} | Sat: {row['Sat']} | DateTime: {row['datetime']} | Version: {row['version']}")
+                    # Apply jitter to all records with this duplicate coordinate pair
+                    mask = (allpixels["y"] == y) & (allpixels["x"] == x)
+                    duplicate_indices = allpixels[mask].index
+
+                    # Store original coordinates before jittering
+                    original_coords = allpixels.loc[duplicate_indices, ["y", "x"]].values
+                    
+                    # Generate jitter for each duplicate record
+                    jitter = np.random.normal(0, 1e-6, (len(duplicate_indices), 2))
+                    
+                    # Apply jitter to y and x columns
+                    allpixels.loc[duplicate_indices, "y"] = allpixels.loc[duplicate_indices, "y"] + jitter[:, 0]
+                    allpixels.loc[duplicate_indices, "x"] = allpixels.loc[duplicate_indices, "x"] + jitter[:, 1]
+
+                    # Log the before/after differences
+                    logger.info(f"    Applied jitter to {len(duplicate_indices)} records:")
+                    for i, idx in enumerate(duplicate_indices):
+                        orig_y, orig_x = original_coords[i]
+                        new_y = allpixels.loc[idx, "y"]
+                        new_x = allpixels.loc[idx, "x"]
+                        diff_y = new_y - orig_y
+                        diff_x = new_x - orig_x
+                        
+                        logger.info(f"      ({orig_y:.8f}, {orig_x:.8f}) -> ({new_y:.8f}, {new_x:.8f}) | Diff: ({diff_y:.2e}, {diff_x:.2e})")
+                
+                # Verify that duplicates are resolved
+                final_coord_counts = allpixels.groupby(["y", "x"]).size()
+                final_duplicated_coords = final_coord_counts[final_coord_counts > 1]
+                
+                if len(final_duplicated_coords) == 0:
+                    logger.info("Successfully resolved all remaining duplicate coordinates with jittering")
+                else:
+                    logger.warning(f"Still have {len(final_duplicated_coords)} duplicate coordinates after jittering - this should not happen!")
+
+    ###########################################################################
+    ############################## END ########################################
+    ###########################################################################
 
     allpixels["fid"] = -1
     allpixels["in_fline"] = None

--- a/fireatlas/FireMain.py
+++ b/fireatlas/FireMain.py
@@ -703,10 +703,11 @@ def Fire_Forward(tst: TimeStep, ted: TimeStep, restart=False, region=None, read_
     else:
         allpixels = pd.concat(non_empty_dfs)
 
-    if settings.FIRE_NRT == True:
+    if settings.FIRE_NRT == True: # Check for rare case with dupliated NRT pixels exist. Flag and remove them if detected. 
         allpixels = flag_and_remove_duplicate_pixels(allpixels)
 
-    # look for coincident pixels where two satellites have the exact lat/lon pair
+    # Look for also rare case where two satellites have the exact lat/lon pair at different times.
+    # This is for both NRT and archival runs
     all_pixels = adjust_coincident_pixels(allpixels)
 
     allpixels["fid"] = -1

--- a/fireatlas/FireVector.py
+++ b/fireatlas/FireVector.py
@@ -97,23 +97,13 @@ def doConvH(locs):
         calculated hull shape
     """
     # calculate the convex hull using scipy.spatial.ConvexHull
-    try: 
-        qhull = ConvexHull(locs)
-        # derive qhull object vertices
-        verts = locs[qhull.vertices]
-        # convert vertices to polygon
-        hull = Polygon(verts)
-    
-    except QhullError as e:
-        logger.info(f'Encountered convex hull error: {e}\nTrying jitter...')
-        
-        jittered_locs = locs + np.random.normal(0, 1e-6, locs.shape) # random noise
-        qhull = ConvexHull(jittered_locs) # try again
-        # derive qhull object vertices
-        verts = jittered_locs[qhull.vertices]
-        # convert vertices to polygon
-        hull = Polygon(verts)
-        
+
+    qhull = ConvexHull(locs)
+    # derive qhull object vertices
+    verts = locs[qhull.vertices]
+    # convert vertices to polygon
+    hull = Polygon(verts)
+            
     return hull
 
 
@@ -134,7 +124,7 @@ def cal_hull(locs):
         buf = settings.VIIRSbuf
     elif settings.FIRE_SENSOR == "mcd64":
         buf = settings.MCD64buf
-
+    
     # number of pixels
     nfp = len(locs)
     hull = None

--- a/fireatlas/preprocess.py
+++ b/fireatlas/preprocess.py
@@ -18,6 +18,7 @@ from fireatlas.FireClustering import do_clustering
 from fireatlas.FireTime import t_generator, t2dt, t_nb, t_nd, t_nm
 from fireatlas import FireIO, FireMain, settings, FireTime
 
+
 def preprocessed_region_filename(region: Region, location: Location = None):
     return os.path.join(
         settings.get_path(location), settings.PREPROCESSED_DIR, region[0], f"{region[0]}.json"
@@ -366,14 +367,19 @@ def preprocess_input_file(filepath: str, filepath_prev: str | None, filepath_nex
         
     df = FireIO.AFP_setampm(df)
     df["Sat"] = sat 
-
     # groupby days and if there are more than 1 days, include a progress bar
     gb = df.groupby(df["local_datetime"].dt.date)
-
+    
     # return selected columns
-    df = df[
-        ["Lat", "Lon", "FRP", "Sat", "DT", "DS", "input_filename", "datetime", "ampm"]
-    ]
+    
+    if settings.FIRE_NRT == True: # preserve version code if working with NRT data
+        df = df[
+            ["Lat", "Lon", "FRP", "Sat", "DT", "DS", "input_filename", "datetime", "ampm", "version"]
+        ]
+    else: 
+        df = df[
+            ["Lat", "Lon", "FRP", "Sat", "DT", "DS", "input_filename", "datetime", "ampm"]
+        ]
 
     output_paths = []
 
@@ -383,15 +389,13 @@ def preprocess_input_file(filepath: str, filepath_prev: str | None, filepath_nex
     for day, data in gb:
         for ampm in ["AM", "PM"]:
             time_filtered_df = data.loc[data["ampm"] == ampm]
-            
             if len(time_filtered_df)>0: # if there's data for this ampm condition, write it out
                 output_filepath = preprocessed_filename(
                     (day.year, day.month, day.day, ampm), sat=sat, location="local"
                 )
-    
+                
                 # make nested path if necessary
                 os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
-    
                 # save active pixels at this time step (day and ampm filter)
                 time_filtered_df.to_csv(output_filepath, index=False)
     
@@ -484,7 +488,6 @@ def read_preprocessed_input(
     
     filename = preprocessed_filename(t, sat=sat, location=location)
     df = pd.read_csv(filename)
-
     return df
 
 
@@ -556,6 +559,9 @@ def preprocess_region_t(
         "x",
         "y",
     ]
+
+    if settings.FIRE_NRT == True:
+        columns.append("version") # preserve version type with NRT data
 
     if not df.empty:
         # return selected columns

--- a/fireatlas/preprocess.py
+++ b/fireatlas/preprocess.py
@@ -335,7 +335,7 @@ def preprocess_input_file(filepath: str, filepath_prev: str | None, filepath_nex
             df = FireIO.read_FIRMS_VIIRS_NRT(f)
         elif "FIRMS_VIIRS_NOAA20_SP" in f: 
             sat = "NOAA20" 
-            df = FireIO.read_FIRMS_VIIRS_SP
+            df = FireIO.read_FIRMS_VIIRS_SP(f)
             df = df.loc[df["Type"] == 0]
             # Type filter: inferred hot spot type == presumed vegetation fire
         elif "FIRMS_VIIRS_NOAA21_NRT" in f: 


### PR DESCRIPTION
(**_phew_** - _this was a tricky one._)

#### This PR is meant to handle duplicated VIIRS points in the NRT workflows. 

What changed?

1. Added the "version" column to all NRT preprocessed text files. This was previously omitted, but now allows us to inspect whether a duplicated VIIRS point is due to that same point being processed by a different algorithm version (ex: 2.0 NRT vs 2.0/2.1 URT)
2. Checks `allpixels` for duplicated VIIRS points. These could fall into three categories: 1) "true"
 duplicates (a point from a given satellite and time is copied exactly); 2) "version" duplicates (points are from the same satellite at the same time, but differ by version number); and 3) "coincident" duplicates, representing legitimate data observed by two separate satellites at two different times. 
3. Duplicates which fall into the first two categories are dropped based on a preference for "NRT" over "URT" version categories, and then higher version numbers (e.g., 2.1 > 2.0) in the unexpected case of ties for the first condition. 
4. All remaining duplicates are then assumed to be "coincident". These locations are logged and a jitter is applied remove their degeneracy. The differences between the new and original locations are also logged, and the algorithm continues as normal.
5. (DELETED LINES): My prior attempt to resolve this issue involved writing exception handling directly into the convex and concave hull functions. I have now moved this processing step much earlier in the workflow to act directly on the `allpixels` object. I have since removed the exception handling in the hull functions, given the issue has been solved upstream. That said, this means the functions will _still_ fail if there is a new condition not captured in this PR. This is intentional and to alert us to any unexpected new issues. 

#### TESTS: 

1. I have been able to replicate and resolve this issue regarding "coincident" detections. A sample of the output is here: 

```
2025-09-02 09:03:19,019 - fireatlas.FireLog - INFO - Searching for duplicated points...
2025-09-02 09:03:19,024 - fireatlas.FireLog - WARNING - There are 1 potentially duplicated coordinate pairs
2025-09-02 09:03:19,044 - fireatlas.FireLog - INFO - Removed 0 duplicated points for the same sensor and time after inspection.
2025-09-02 09:03:19,049 - fireatlas.FireLog - WARNING - There are still 1 potentially duplicated coordinate pairs
2025-09-02 09:03:19,050 - fireatlas.FireLog - INFO - Details of remaining duplicate coordinate pairs:
2025-09-02 09:03:19,051 - fireatlas.FireLog - INFO -   Coordinate (2272867.64979916, -9107970.04829216) appears 2 times:
2025-09-02 09:03:19,053 - fireatlas.FireLog - INFO -     Y: 2272867.64979916 | X: -9107970.04829216 | Sat: SNPP | DateTime: 2025-06-01 07:50:00 | Version: 2.0NRT
2025-09-02 09:03:19,053 - fireatlas.FireLog - INFO -     Y: 2272867.64979916 | X: -9107970.04829216 | Sat: NOAA20 | DateTime: 2025-06-01 08:11:00 | Version: 2.0NRT
2025-09-02 09:03:19,057 - fireatlas.FireLog - INFO -     Applied jitter to 2 records:
2025-09-02 09:03:19,058 - fireatlas.FireLog - INFO -       (2272867.64979916, -9107970.04829216) -> (2272867.64979962, -9107970.04829269) | Diff: (4.63e-07, -5.27e-07)
2025-09-02 09:03:19,059 - fireatlas.FireLog - INFO -       (2272867.64979916, -9107970.04829216) -> (2272867.64979808, -9107970.04829274) | Diff: (-1.08e-06, -5.81e-07)
2025-09-02 09:03:19,063 - fireatlas.FireLog - INFO - Successfully resolved all remaining duplicate coordinates with jittering
```

^^^ In this case, duplicates are detected but are not removed by addressing the "true" and "version" duplicate scenarios. This is logged and the code proceeds to alter the coincident points, which in this case came from two SNPP and NOAA20 observations about 20min apart. 

2. I regret to say that I have been unable to replicate the original errors that clued me into the "true" and "version" duplicate issues. This error consistently occurs when using the DPS, but I am not able to reproduce it in the ADE. As such, I've written what I appears to be the correct logic, but this still needs to be tested on DPS. 

@mccabete and @zebbecker, if this sounds good to you all, I recommend looking over the changes in FireMain and merging if they look good. Then I can try to replicate the issue on DPS. Let me know if there are questions!  

