### PR TITLE
Zb/preprocess hourly updates

### DIFF
--- a/.github/workflows/manual-v3.yaml
+++ b/.github/workflows/manual-v3.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'eis-feds-dask-coordinator-v3'
       github_ref:
-        description: 'Branch name or version tag, e.g: 1.5.0'
+        description: 'Branch name or version tag, e.g: 1.5.1'
         required: true
       username:
         description: 'Your MAAP username'

--- a/.github/workflows/schedule-bolivia_NOAA20-nrt.yaml
+++ b/.github/workflows/schedule-bolivia_NOAA20-nrt.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.5.0
+          github_ref: 1.5.1
           username: mccabete
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-borealna-nrt-v3.yaml
+++ b/.github/workflows/schedule-borealna-nrt-v3.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.5.0
+          github_ref: 1.5.1
           username: zbecker
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-conus-nrt-v3.yaml
+++ b/.github/workflows/schedule-conus-nrt-v3.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
       with:
         algo_name: eis-feds-dask-coordinator-v3
-        github_ref: 1.5.0
+        github_ref: 1.5.1
         username: zbecker
         queue: maap-dps-eis-worker-128gb
         maap_image_env: ubuntu

--- a/.github/workflows/schedule-hawaii-nrt-v3.yaml
+++ b/.github/workflows/schedule-hawaii-nrt-v3.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.5.0
+          github_ref: 1.5.1
           username: zbecker
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-nrt-date-update-current-day.yaml
+++ b/.github/workflows/schedule-nrt-date-update-current-day.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.5.0
+          github_ref: 1.5.1
           username: zbecker
           queue: maap-dps-eis-worker-32gb
           maap_image_env: ubuntu

--- a/.github/workflows/schedule-russia-east-nrt-v3.yaml
+++ b/.github/workflows/schedule-russia-east-nrt-v3.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: Earth-Information-System/fireatlas/.github/actions/run-dps-job-v3@conus-dps
         with:
           algo_name: eis-feds-dask-coordinator-v3
-          github_ref: 1.5.0
+          github_ref: 1.5.1
           username: zbecker
           queue: maap-dps-eis-worker-128gb
           maap_image_env: ubuntu

--- a/fireatlas/FireRunDaskCoordinator.py
+++ b/fireatlas/FireRunDaskCoordinator.py
@@ -49,7 +49,7 @@ from fireatlas.FireIO import (
     FIRMS_VIIRS_NOAA20_NRT_filepath,
     FIRMS_VIIRS_NOAA21_NRT_filepath
 )
-from fireatlas.FireTime import t_generator, d2t, t_nm, t_nd
+from fireatlas.FireTime import t_generator, d2t, t_nm, t_nd, dt2t
 from fireatlas.FireLog import logger
 from fireatlas import settings
 import geopandas as gpd
@@ -144,7 +144,9 @@ def job_preprocess_region(region: Region):
 
 def job_nrt_current_day_updates(client: Client):
     """hourly update the NRT files and prep
-    Updates files for today and the two previous days.
+    Updates files for today and the two previous days. Forces preprocessing regardless 
+    of if preprocessed files are already present for these days so that a partially
+    empty preprocessed file will not be cached as such. 
     """
     futures, source, now = [], settings.FIRE_SOURCE, datetime.now()
 
@@ -152,13 +154,24 @@ def job_nrt_current_day_updates(client: Client):
         sats = ["SNPP", "NOAA20", "NOAA21"]
     else:
         sats = [source]
-
+        
+    download_futures = {} # (t, sat) -> dask future 
+    preprocess_tasks = {} # (t, sat) -> filepath 
+    
     for sat in sats:
-        futures.extend(client.map(update_FIRMS, *[
-            (now.date(), (now-timedelta(days=1)).date(), (now-timedelta(days=2)).date()),
-            (sat, sat, sat),
-            ("NRT", "NRT", "NRT")
-        ]))
+        for d in [now, now-timedelta(days=1), now-timedelta(days=2)]:
+            t = tuple(dt2t(d))
+            d = d.date()
+            download_futures[(t, sat)] = client.submit(update_FIRMS, d, sat, "NRT")
+
+    # finish all downloads before starting preprocessing 
+    downloaded_paths = client.gather(download_futures)
+    preprocess_tasks.update(downloaded_paths) 
+
+    # always force preprocessing for new downloads 
+    for (tk, satk), fp in preprocess_tasks.items(): 
+        tk = list(tk) 
+        futures.append(client.submit(preprocess_daily_file, fp, tk, satk))
 
     return futures
 

--- a/fireatlas/FireTime.py
+++ b/fireatlas/FireTime.py
@@ -244,22 +244,33 @@ def d2t(year, month, day, ampm):
     return t
 
 
-def dt2t(dt):
+def dt2t(indt):
     """convert datetime to a t tuple
     Parameters
     ----------
-    dt : datetime datetime
-        datetime
-    Returns
-    -------
-    t : tuple, (int,int,int,str)
-        the year, month, day and 'AM'|'PM'
-    """
-    dlh = {"AM": 0, "PM": 12}
-    dhl = {0: "AM", 12: "PM"}
+        dt : datetime object in local time 
 
-    t = [dt.year, dt.month, dt.day, dhl[dt.hour]]
-    return t
+    
+    Expected behavior: 
+    1/1 07:00 to 1/1 17:59 -> 1/1 PM
+    1/1 18:00 to 1/2 06:59 -> 1/2 AM 
+    1/2 07:00 to 1/2 17:59 -> 1/2 PM 
+    1/2 18:00 to 1/3 06:59 -> 1/3 AM 
+
+    This is based on the existing logic in FireIO.AFP_setampm
+
+    Returns 
+    -------
+        t : TimeStep ([int year, int month, int day, "AM" or "PM"])
+    """
+
+    if indt.hour <= 6: 
+        return [indt.year, indt.month, indt.day, "AM"]
+    elif indt.hour < 18: 
+        return [indt.year, indt.month, indt.day, "PM"]
+    else: # belongs to AM overpass for following day
+        nextday = indt + timedelta(days=1)
+        return [nextday.year, nextday.month, nextday.day, "AM"]
 
 
 def ftrange(firstday, lastday):

--- a/maap_runtime/archive/algorithm_config.yaml
+++ b/maap_runtime/archive/algorithm_config.yaml
@@ -1,6 +1,6 @@
 algorithm_name: eis-feds-archive
 algorithm_description: "Run FEDS for large regions/time periods retrospectively"
-algorithm_version: 1.5.0
+algorithm_version: checkpoints
 environment: ubuntu
 repository_url: https://github.com/Earth-Information-System/fireatlas.git
 docker_container_url: "mas.maap-project.org/root/maap-workspaces/custom_images/maap_base:v5.0.0"

--- a/maap_runtime/coordinator/algorithm_config.yaml
+++ b/maap_runtime/coordinator/algorithm_config.yaml
@@ -1,6 +1,6 @@
 algorithm_name: eis-feds-dask-coordinator-v3
 algorithm_description: "coordinator for all regional jobs, preprocess and FireForward steps"
-algorithm_version: 1.5.0
+algorithm_version: 1.5.1
 environment: ubuntu
 repository_url: https://github.com/Earth-Information-System/fireatlas.git
 docker_container_url: "mas.maap-project.org/root/maap-workspaces/custom_images/maap_base:v5.0.0"

--- a/tests/test_firetime.py
+++ b/tests/test_firetime.py
@@ -1,0 +1,22 @@
+import pytest 
+from fireatlas.FireTime import dt2t
+import datetime as dt
+
+def test_dt2t_simple():
+       """Test with old version (00:00:00 and 12:00:00 only)"""
+       am = dt.datetime(2025, 1, 1, 0, 0, 0)
+       pm = dt.datetime(2025, 1, 1, 12, 0, 0)
+
+       assert dt2t(am) == [2025, 1, 1, "AM"]
+       assert dt2t(pm) == [2025, 1, 1, "PM"]
+
+def test_dt2t():
+       
+       assert dt2t(dt.datetime(2025, 1, 1, 7, 0, 0)) == [2025, 1, 1, "PM"]
+       assert dt2t(dt.datetime(2025, 1, 1, 17, 59, 59)) == [2025, 1, 1, "PM"]
+       assert dt2t(dt.datetime(2025, 1, 1, 18, 0, 0 )) == [2025, 1, 2, "AM"]
+       assert dt2t(dt.datetime(2025, 1, 2, 6, 59, 59)) == [2025, 1, 2, "AM"]
+       assert dt2t(dt.datetime(2025, 1, 2, 7, 0, 0)) == [2025, 1, 2, "PM"]
+       assert dt2t(dt.datetime(2025, 1, 2, 17, 59, 59)) == [2025, 1, 2, "PM"]
+       assert dt2t(dt.datetime(2025, 1, 2, 18, 0, 0)) == [2025, 1, 3, "AM"]
+       


### PR DESCRIPTION
Because the raw input files downloaded for the current day may be incomplete at any given moment, forces the global preprocessed file for each satellite to be rewritten when job_nrt_current_day_update fetches the latest input data. Otherwise, we get stuck with an incomplete preprocessed file cached. 